### PR TITLE
COMPILE_TARGET setting should be way sexier

### DIFF
--- a/RakeFile
+++ b/RakeFile
@@ -1,4 +1,4 @@
-COMPILE_TARGET = ENV['config'].nil? ? "release" : ENV['config']
+COMPILE_TARGET = ENV['config'] || 'release'
 
 include FileTest
 require 'albacore'


### PR DESCRIPTION
You don't need a ternary expression to null-coalesce. You can use a  
simple boolean expression. If there's a value in `ENV['config']`, it 
evaluates `true` and returns the value. Otherwise, it evaluates 
`false` and takes your default.

Also, `nil` always evaluates to `false`. So, you don't ever need to 
write `x.nil?`. You can just post-fix like `<expr> unless x`. 
Although that doesn't affect your expression choice in this case. It's
just FYI.
