### PR TITLE
You should never use nil? in a postfix expr

### DIFF
--- a/RakeFile
+++ b/RakeFile
@@ -46,8 +46,8 @@ assemblyinfo :version do |asm|
   rescue
     commit = "git unavailable"
   end
-  puts "##teamcity[buildNumber '#{build_number}']" unless tc_build_number.nil?
-  puts "Version: #{build_number}" if tc_build_number.nil?
+  puts "##teamcity[buildNumber '#{build_number}']" if tc_build_number
+  puts "Version: #{build_number}" unless tc_build_number
   asm.trademark = commit
   asm.product_name = PRODUCT
   asm.description = build_number


### PR DESCRIPTION
`nil` values always evaluate `false` and anything else (except, of course, `false`) evaulates `true`. So, you can write your postfix expressions a lot nicer. In the code above, you can read it like...
- print the teamcity build number if it exists
- print the "manual" build number if the teamcity build number does not exist
