### PR TITLE
Added overload to SelectionValuesAttribute for enums

### DIFF
--- a/src/StoryTeller.Samples/Fixtures/SelectionListFixture.cs
+++ b/src/StoryTeller.Samples/Fixtures/SelectionListFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using StoryTeller.Engine;
 
 namespace StoryTeller.Samples.Grammars
@@ -26,6 +27,19 @@ namespace StoryTeller.Samples.Grammars
         {
             return first + " " + last;
         }
+
+        [FormatAs("The Enum value of {option} should be {selectedOption}")]
+        [return: AliasAs("selectedOption")]
+        public string TheEnumOptionIs([SelectionValues(typeof(SampleEnum))] string option)
+        {
+            return EnumValueFor<SampleEnum>(option).ToString();
+        }
+        
+        private static int EnumValueFor<T>(string value) where T : struct
+        {
+            var parsed = Enum.Parse(typeof(T), value);
+            return (int)parsed;
+        }
     }
 
     public class NameTable : DecisionTableGrammar
@@ -44,5 +58,11 @@ namespace StoryTeller.Samples.Grammars
         public string Last { set { _last = value; } }
 
         public string Fullname { get { return _first + " " + _last; } }
+    }
+
+    public enum SampleEnum
+    {
+        FirstOption,
+        SecondOption
     }
 }

--- a/src/StoryTeller.Samples/Tests/General/Selection List Values.xml
+++ b/src/StoryTeller.Samples/Tests/General/Selection List Values.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0"?>
 <Test name="Selection List Values" lifecycle="Acceptance">
   <SelectionList>
-    <TheNameIs first="Jeremy" last="Smith" fullname="Jeremy Smith" />
-    <FirstAndLastName>
+    <TheNameIs first="Jeremy" last="Smith" fullname="Jeremy Smith" isStep="True" />
+    <FirstAndLastName isStep="True">
       <table>
-        <table first="Hank" last="Miller" fullname="Hank Miller" />
-        <table first="Harold" last="Miller" fullname="Harold Mueller" />
+        <table first="Hank" last="Miller" fullname="Hank Miller" isStep="True" />
+        <table first="Harold" last="Miller" fullname="Harold Mueller" isStep="True" />
       </table>
     </FirstAndLastName>
-    <names>
+    <names isStep="True">
       <table>
-        <table First="Tobin" Last="Smith" Fullname="Tobin Smith" />
+        <table First="Tobin" Last="Smith" Fullname="Tobin Smith" isStep="True" />
       </table>
     </names>
+    <TheEnumOptionIs isStep="True" option="FirstOption" selectedOption="0" />
   </SelectionList>
 </Test>

--- a/src/StoryTeller.Testing/Engine/SelectionValueAttributeTester.cs
+++ b/src/StoryTeller.Testing/Engine/SelectionValueAttributeTester.cs
@@ -39,5 +39,21 @@ namespace StoryTeller.Testing.Engine
 
             cell.SelectionValues.ShouldHaveTheSameElementsAs("Jeremy", "Max", "Monte");
         }
+
+        [Test]
+        public void set_the_list_value_when_the_attribute_has_an_enum_type()
+        {
+            var att = new SelectionValuesAttribute(typeof(TestEnum));
+            att.SetList(fixture, cell);
+
+            cell.SelectionValues.ShouldHaveTheSameElementsAs("One", "Two", "Three");
+        }
+
+        private enum TestEnum
+        {
+            One,
+            Two,
+            Three
+        }
     }
 }

--- a/src/StoryTeller/Engine/SelectionValuesAttribute.cs
+++ b/src/StoryTeller/Engine/SelectionValuesAttribute.cs
@@ -8,6 +8,11 @@ namespace StoryTeller.Engine
     {
         private readonly string[] _values;
 
+        public SelectionValuesAttribute(Type enumType)
+            : this(Enum.GetNames(enumType))
+        {
+        }
+
         public SelectionValuesAttribute(params string[] values)
         {
             if (values.Length == 0)


### PR DESCRIPTION
You still have to parse back to the enum on the other side, but this at least automatically adds the selection values from the enum type.
