### PR TITLE
Expose command line flag for default TimeOut

### DIFF
--- a/src/StoryTeller.Testing/CommandLine/RunInputTester.cs
+++ b/src/StoryTeller.Testing/CommandLine/RunInputTester.cs
@@ -81,5 +81,16 @@ namespace StoryTeller.Testing.CommandLine
             input.LoadProject().CompileTarget.ShouldEqual("release");
         }
 
+        [Test]
+        public void respects_the_timeout_flag()
+        {
+            var project = new Project { Name = "MyProject", TimeoutInSeconds = 60 };
+            project.Save("myproject.xml");
+
+            var input = new RunInput { Path = "myproject.xml", TimeoutFlag = 120 };
+
+            input.LoadProject().TimeoutInSeconds.ShouldEqual(120);
+        }
+
     }
 }

--- a/src/StoryTeller/CommandLine/RunInput.cs
+++ b/src/StoryTeller/CommandLine/RunInput.cs
@@ -24,6 +24,9 @@ namespace StoryTeller.CommandLine
         [Description("Storyteller test mode profile for systems like Serenity that use this")]
         public string ProfileFlag { get; set; }
 
+        [Description("Optional. Default project timeout in seconds.")]
+        public int? TimeoutFlag { get; set; }
+
         [Description("Optional. Only runs tests with desired lifecyle")]
         public Lifecycle LifecycleFlag { get; set; }
 
@@ -57,6 +60,11 @@ namespace StoryTeller.CommandLine
             if (CompileFlag.IsNotEmpty())
             {
                 project.CompileTarget = CompileFlag;
+            }
+
+            if (TimeoutFlag.HasValue)
+            {
+                project.TimeoutInSeconds = TimeoutFlag.Value;
             }
 
             return project;


### PR DESCRIPTION
Originally this was only configurable through the project xml. This
makes it easier to pair this with FubuRake and not need the config XML
file at all.

I'll have a pull request for FubuRake to expose the timeout there as well.
