### PR TITLE
Link to Storyteller2 repository

### DIFF
--- a/src/Storyteller.Docs/project.xml
+++ b/src/Storyteller.Docs/project.xml
@@ -4,7 +4,7 @@
   <Description>DSL Tooling for Acceptance Testing in .Net</Description>
   <Name>Storyteller</Name>
   <TwitterHandle />
-  <GitHubPage>http://github.com/DarthFubuMVC/Storyteller</GitHubPage>
+  <GitHubPage>http://github.com/DarthFubuMVC/Storyteller2</GitHubPage>
   <UserGroupUrl>https://groups.google.com/forum/?fromgroups#!forum/fubumvc-devel</UserGroupUrl>
   <BuildServerUrl>http://build.fubu-project.org/project.html?projectId=bt76&amp;tab=projectOverview</BuildServerUrl>
   <TeamCityBuildType />


### PR DESCRIPTION
The Github link on http://fubuworld.com/storyteller/ points to the original DarthFubuMVC/storyteller repository, which has the subtitle `OBSOLETE, see Storyteller2`. This pull updates the link to the storyteller2 codebase.
