### PR TITLE
Fix BatchWatcher to handle no specs

### DIFF
--- a/src/StoryTeller.Testing/Engine/BatchWatcherTester.cs
+++ b/src/StoryTeller.Testing/Engine/BatchWatcherTester.cs
@@ -1,0 +1,60 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Shouldly;
+using StoryTeller.Engine;
+using StoryTeller.Grammars;
+using StoryTeller.Model;
+
+namespace StoryTeller.Testing.Engine
+{
+    [TestFixture]
+    public class BatchWatcherTester
+    {
+        [Test]
+        public void complete_immediately_with_no_specs()
+        {
+            var watcher = new BatchWatcher(Enumerable.Empty<Specification>());
+            watcher.Task.IsCompleted.ShouldBeTrue();
+            watcher.Task.Result.ShouldBe(Enumerable.Empty<BatchRecord>());
+        }
+
+        [Test]
+        public void does_not_complete_until_all_specs_are_handled()
+        {
+            var specs = new[]
+            {
+                new Specification(),
+                new Specification(),
+                new Specification()
+            };
+            var watcher = new BatchWatcher(specs);
+            watcher.Task.IsCompleted.ShouldBeFalse();
+
+            var results = specs.Select(x => new SpecResults()).ToArray();
+
+            var specPlans = specs.Select(x =>
+            {
+                return new SpecificationPlan(Enumerable.Empty<CompositeExecution>())
+                {
+                    Specification = x
+                };
+            }).ToArray();
+
+            for (var i = 0; i < specs.Length; i++)
+            {
+                watcher.SpecHandled(specPlans[i], results[i]);
+
+                if (i < specs.Length - 1)
+                {
+                    watcher.Task.IsCompleted.ShouldBeFalse();
+                }
+            }
+
+            watcher.Task.IsCompleted.ShouldBeTrue();
+            var records = watcher.Task.Result;
+
+            records.Select(x => x.results).ShouldBe(results);
+            records.Select(x => x.specification).ShouldBe(specs);
+        }
+    }
+}

--- a/src/StoryTeller.Testing/StoryTeller.Testing.csproj
+++ b/src/StoryTeller.Testing/StoryTeller.Testing.csproj
@@ -82,6 +82,7 @@
     <Compile Include="EndToEndExecution\simple_method_grammars.cs" />
     <Compile Include="EndToEnd\simplest_possible_execution.cs" />
     <Compile Include="Engine\BatchExecutionModeTester.cs" />
+    <Compile Include="Engine\BatchWatcherTester.cs" />
     <Compile Include="Engine\batch_running_failure_cases_integration_specs.cs" />
     <Compile Include="Engine\CountsTester.cs" />
     <Compile Include="Engine\EngineControllerTester.cs" />

--- a/src/StoryTeller/Engine/BatchWatcher.cs
+++ b/src/StoryTeller/Engine/BatchWatcher.cs
@@ -13,24 +13,30 @@ namespace StoryTeller.Engine
 
         public BatchWatcher(IEnumerable<Specification> specs)
         {
-            specs.Each(x => _records.Add(x.id, new BatchRecord{specification = x}));
+            specs.Each(x => _records.Add(x.id, new BatchRecord {specification = x}));
             _task = new TaskCompletionSource<IEnumerable<BatchRecord>>();
+            CompleteCheck();
         }
 
-        public Task<IEnumerable<BatchRecord>>  Task
+        public Task<IEnumerable<BatchRecord>> Task
         {
             get { return _task.Task; }
         }
-        
+
         public void SpecHandled(SpecificationPlan plan, SpecResults specResults)
         {
             var record = _records[plan.Specification.id];
             record.results = specResults;
             record.specification = plan.Specification;
-
-            if (IsCompleted()) _task.SetResult(_records.Values.ToArray());
+            CompleteCheck();
         }
-         
+
+        private void CompleteCheck()
+        {
+            if (IsCompleted())
+                _task.SetResult(_records.Values.ToArray());
+        }
+
 
         public bool IsCompleted()
         {


### PR DESCRIPTION
Without this it will wait indefinitely if an empty IEnumerable is provided.