### PR TITLE
Show all spec links regardless of mode

### DIFF
--- a/client/components/editing/header/spec-links.jsx
+++ b/client/components/editing/header/spec-links.jsx
@@ -4,46 +4,46 @@ var React = require("react");
 var {Button, ButtonGroup} = require('react-bootstrap');
 
 var LinkButton = React.createClass({
-	render: function(){
-		var onclick = e => {
-			window.location = this.props.href;
-			e.stopPropagation();
-		}
+  render: function(){
+    var onclick = e => {
+      window.location = this.props.href;
+      e.stopPropagation();
+    }
 
-		return (<Button onClick={onclick}>{this.props.text}</Button>);
-	}
+    return (<Button onClick={onclick}>{this.props.text}</Button>);
+  }
 });
 
 var SpecLinks = React.createClass({
-	buildLinks(){
-		var links = [];
-		if (this.props.mode != 'editing'){
-			var elem = (<LinkButton href={'#/spec/editing/' + this.props.id} text="Editor"/>);
-			links.push(elem);
-		}
+  buildLinks(){
+    var links = [];
+    if (this.props.mode != 'editing'){
+      var elem = (<LinkButton href={'#/spec/editing/' + this.props.id} text="Editor"/>);
+      links.push(elem);
+    }
 
-		if (this.props.mode != 'preview'){
-			var elem = (<LinkButton href={'#/spec/preview/' + this.props.id} text="Preview"/>);
-			links.push(elem);
-		}
+    if (this.props.mode != 'preview'){
+      var elem = (<LinkButton href={'#/spec/preview/' + this.props.id} text="Preview"/>);
+      links.push(elem);
+    }
 
-		if (this.props.mode != 'results'){
-			var elem = (<LinkButton href={'#/spec/results/' + this.props.id} text="Results" />);
-			links.push(elem);
-		}
+    if (this.props.mode != 'results'){
+      var elem = (<LinkButton href={'#/spec/results/' + this.props.id} text="Results" />);
+      links.push(elem);
+    }
 
-		return links;
-	},
+    return links;
+  },
 
-	render(){
-		var links = this.buildLinks();
+  render(){
+    var links = this.buildLinks();
 
-		return (
-			<ButtonGroup>
-				{links}
-			</ButtonGroup>
-		);
-	}
+    return (
+      <ButtonGroup>
+        {links}
+      </ButtonGroup>
+    );
+  }
 });
 
 module.exports = SpecLinks;

--- a/client/components/editing/header/spec-links.jsx
+++ b/client/components/editing/header/spec-links.jsx
@@ -10,37 +10,17 @@ var LinkButton = React.createClass({
       e.stopPropagation();
     }
 
-    return (<Button onClick={onclick}>{this.props.text}</Button>);
+    return (<Button onClick={onclick} active={this.props.active}>{this.props.text}</Button>);
   }
 });
 
 var SpecLinks = React.createClass({
-  buildLinks(){
-    var links = [];
-    if (this.props.mode != 'editing'){
-      var elem = (<LinkButton href={'#/spec/editing/' + this.props.id} text="Editor"/>);
-      links.push(elem);
-    }
-
-    if (this.props.mode != 'preview'){
-      var elem = (<LinkButton href={'#/spec/preview/' + this.props.id} text="Preview"/>);
-      links.push(elem);
-    }
-
-    if (this.props.mode != 'results'){
-      var elem = (<LinkButton href={'#/spec/results/' + this.props.id} text="Results" />);
-      links.push(elem);
-    }
-
-    return links;
-  },
-
   render(){
-    var links = this.buildLinks();
-
     return (
       <ButtonGroup>
-        {links}
+        <LinkButton href={'#/spec/preview/' + this.props.id} text="Preview" active={this.props.mode === 'preview'} />
+        <LinkButton href={'#/spec/editing/' + this.props.id} text="Editor" active={this.props.mode === 'editing'} />
+        <LinkButton href={'#/spec/results/' + this.props.id} text="Results" active={this.props.mode === 'results'} />
       </ButtonGroup>
     );
   }

--- a/client/components/header/header.jsx
+++ b/client/components/header/header.jsx
@@ -84,7 +84,7 @@ module.exports = React.createClass({
 				</Navbar>
 				<StatusBar/>
 
-				<SpecProgressBar />;
+				<SpecProgressBar />
 			</div>
 
 		);


### PR DESCRIPTION
After using Storyteller for a little while, I found it confusing that the mode buttons were not in a consistent visibility or position. This change simply displays the 3 mode buttons at all times and adds an active state to the current mode. It also changes the order to line up with the keyboard shortcuts.