### PR TITLE
Internalized fields typed as FubuCore.Utils.Cache<,>

### DIFF
--- a/src/StoryTeller.Samples/Fixtures/SelectionListFixture.cs
+++ b/src/StoryTeller.Samples/Fixtures/SelectionListFixture.cs
@@ -9,7 +9,7 @@ namespace StoryTeller.Samples.Fixtures
     {
         public SelectionListFixture()
         {
-            Lists["surname"].AddValues("Miller", "Smith", "Brown");
+            AddSelectionValues("surname", "Miller", "Smith", "Brown");
 
             this["names"] = new NameTable();
         }

--- a/src/StoryTeller.Samples/GrammarSystem.cs
+++ b/src/StoryTeller.Samples/GrammarSystem.cs
@@ -32,13 +32,14 @@ namespace StoryTeller.Samples
             var handling = CellHandling.Basic();
 
             // Adding a system wide list. 
-            handling.Lists["positions"].AddValues("LB", "OL", "DL", "WR", "RB");
+            handling.AddSystemLevelList("positions", new[] { "LB", "OL", "DL", "WR", "RB" });
 
             // This is where you can register a custom runtime conversion
             handling.Conversions.RegisterRuntimeConversion<PlayerConverter>();
 
             return handling;
         }
+        // ENDSAMPLE
         // ENDSAMPLE
 
         public Task Warmup()

--- a/src/StoryTeller.Testing/FixtureTester.cs
+++ b/src/StoryTeller.Testing/FixtureTester.cs
@@ -20,10 +20,10 @@ namespace StoryTeller.Testing
             fixture.AddSelectionValues("States", "TX", "AR", "MO");
             fixture.AddSelectionValues("Animals", "Lions", "Tigers", "Pumas");
 
-            fixture.Lists["States"].Options.Select(x => x.value)
+            fixture.GetSelectionValues("States")
                 .ShouldHaveTheSameElementsAs("TX", "AR", "MO");
 
-            fixture.Lists["Animals"].Options.Select(x => x.value)
+            fixture.GetSelectionValues("Animals")
                 .ShouldHaveTheSameElementsAs("Lions", "Tigers", "Pumas");
         }
 

--- a/src/StoryTeller.Testing/Model/CellTester.cs
+++ b/src/StoryTeller.Testing/Model/CellTester.cs
@@ -273,10 +273,10 @@ namespace StoryTeller.Testing.Model
         public void if_list_is_not_on_fixture_picks_up_from_cellHandling()
         {
             var handling = CellHandling.Basic();
-            handling.Lists["States"].AddValues("TX", "MO", "AR");
+            handling.AddSystemLevelList("States", new[] { "TX", "MO", "AR" });
 
             var fixture = new Fixture();
-            fixture.Lists.Has("States").ShouldBe(false);
+            fixture.GetSelectionValues("States").ShouldBeEmpty();
 
             var property = ReflectionHelper.GetProperty<CellTarget>(x => x.State);
             var cell = Cell.For(handling, property, fixture);
@@ -288,10 +288,10 @@ namespace StoryTeller.Testing.Model
         public void list_on_fixture_has_precedence()
         {
             var handling = CellHandling.Basic();
-            handling.Lists["States"].AddValues("TX", "MO", "AR");
+            handling.AddSystemLevelList("States", new[] { "TX", "MO", "AR" });
 
             var fixture = new Fixture();
-            fixture.Lists["States"].AddValues("NY", "CT");
+            fixture.AddSelectionValues("States", "NY", "CT");
 
             var property = ReflectionHelper.GetProperty<CellTarget>(x => x.State);
             var cell = Cell.For(handling, property, fixture);

--- a/src/StoryTeller.Testing/cells_reading_lists_integration_specs.cs
+++ b/src/StoryTeller.Testing/cells_reading_lists_integration_specs.cs
@@ -25,6 +25,23 @@ namespace StoryTeller.Testing
         }
 
         [Test]
+        public void get_list_options_from_the_global_handling()
+        {
+            var handling = CellHandling.Basic();
+            
+            var options = new[] { new Option("1", "A"), new Option("2", "B") };
+
+            handling.AddSystemLevelList("Numbers", options);
+
+            var fixture = new SelectionValuesFixture();
+            var model = fixture.Compile(handling);
+
+            model.FindGrammar("DoSomething").ShouldBeOfType<Sentence>()
+                 .FindCell("x").options
+                 .ShouldHaveTheSameElementsAs(options);
+        }
+
+        [Test]
         public void get_list_values_from_fixture()
         {
             var handling = CellHandling.Basic();

--- a/src/StoryTeller/CellHandling.cs
+++ b/src/StoryTeller/CellHandling.cs
@@ -32,7 +32,7 @@ namespace StoryTeller
         /// <summary>
         /// All the system level selection lists
         /// </summary>
-        public readonly Cache<string, OptionList> Lists = new Cache<string, OptionList>(key => new OptionList(key));
+        internal readonly Cache<string, OptionList> Lists = new Cache<string, OptionList>(key => new OptionList(key));
 
         /// <summary>
         /// Add a system level selection list by string values

--- a/src/StoryTeller/Fixture.cs
+++ b/src/StoryTeller/Fixture.cs
@@ -550,7 +550,21 @@ namespace StoryTeller
             Lists[key].AddValues(values);
         }
 
-        public readonly Cache<string, OptionList> Lists = new Cache<string, OptionList>(key => new OptionList(key));
+        /// <summary>
+        /// Gets the values defined for a selection list added using <see cref="AddSelectionValues"/>.
+        /// </summary>
+        /// <param name="key"></param>
+        public IEnumerable<string> GetSelectionValues(string key)
+        {
+            if (Lists.Has(key))
+            {
+                return Lists[key].Options.Select(x => x.value);
+            }
+
+            return Enumerable.Empty<string>();
+        }
+
+        internal readonly Cache<string, OptionList> Lists = new Cache<string, OptionList>(key => new OptionList(key));
 
         /// <summary>
         /// Shortcut to get or set the current object on the context state


### PR DESCRIPTION
Made `FubuCore.Utils.Cache<,>` field named `Lists` on `StoryTeller.Fixture` and
`StoryTeller.CellHandling` types `internal` to avoid confusing consumers who don't have
access to the merged `FubuCore.Utils.Cache<,>` type. This resolves issue #446.