### PR TITLE
Outline items aren't as spread out

### DIFF
--- a/client/components/editing/spec-outline.jsx
+++ b/client/components/editing/spec-outline.jsx
@@ -39,7 +39,7 @@ var OutlineItem = React.createClass({
 		return (
 			<li key={this.props.id}>
 				<a href="#" id={id} onClick={onclick}>{this.props.title}</a>
-				<ul>{this.props.children}</ul>
+				<ul style={{paddingLeft: '15px'}}>{this.props.children}</ul>
 			</li>
 		);
 	}


### PR DESCRIPTION
The default padding for `ul` in `ul` is 

```css
padding: 40px;
``` 

which is pretty spread out. It adds up pretty quickly when you have nested outline items.