### PR TITLE
Added tree feature to outline items

### DIFF
--- a/client/components/editing/spec-outline.jsx
+++ b/client/components/editing/spec-outline.jsx
@@ -83,7 +83,7 @@ var OutlineItem = React.createClass({
 var OutlineContainer = React.createClass({
 	render: function() {
 		return (
-			<ul className="outline-container spec-outline">
+			<ul className="outline-container">
 			{
 				this.props.children.map(item => {
 					return item.active ?

--- a/client/components/editing/spec-outline.jsx
+++ b/client/components/editing/spec-outline.jsx
@@ -83,7 +83,7 @@ var OutlineItem = React.createClass({
 var OutlineContainer = React.createClass({
 	render: function() {
 		return (
-			<ul className="outline-container">
+			<ul className="outline-container spec-outline">
 			{
 				this.props.children.map(item => {
 					return item.active ?
@@ -98,6 +98,10 @@ var OutlineContainer = React.createClass({
 
 module.exports = React.createClass({
 	render: function(){
-		return <OutlineContainer children={this.props.outline.children} />;
+		return (
+			<div className="spec-outline">
+				<OutlineContainer children={this.props.outline.children} />
+			</div>
+		);
 	}
 });

--- a/client/components/editing/spec-outline.jsx
+++ b/client/components/editing/spec-outline.jsx
@@ -1,28 +1,60 @@
 var React = require("react");
 var Postal = require('postal');
+var Icons = require('./../icons');
 
 // {id: , active: , title: , children:[]}
 
-var buildItem = function(item){
-	var children = item.children.map(x => buildItem(x));
-
-	if (item.active){
-		return ( <ActiveOutlineItem key={item.id} title={item.title} children={children}/> );
-	}
-	else {
-		return ( <OutlineItem key={item.id} title={item.title} id={item.id} children={children} /> );
-	}
-}
+var FolderOpen = Icons['folder-open'];
+var FolderClosed = Icons['folder-closed'];
 
 var ActiveOutlineItem = React.createClass({
+	getInitialState: function() {
+		return {
+			collapsed: false,
+			collapsedIcon: <FolderOpen />
+		};
+	},
+
+	collapse: function(e) {
+		this.setState({
+			collapsed: !this.state.collapsed,
+			collapsedIcon: this.state.collapsed ? <FolderOpen /> : <FolderClosed />
+		});
+
+		e.preventDefault();
+	},
+
 	render: function(){
+		var container = this.props.children.length > 0 && !this.state.collapsed ? <OutlineContainer children={this.props.children} /> : '';
+		var collapser = this.props.children.length > 0 ? <a className="toggle" href='#' onClick={this.collapse}>{this.state.collapsedIcon}</a> : '';
 		return (
-			<li key={this.props.id}><b>{this.props.title}</b><ul>{this.props.children}</ul></li>
+			<li key={this.props.id}>
+				{collapser}
+				<b>{this.props.title}</b>
+				{container}
+			</li>
 		);
 	}
 });
 
 var OutlineItem = React.createClass({
+	getInitialState: function() {
+		return {
+			collapsed: false,
+			collapsedIcon: <FolderOpen />
+		};
+	},
+
+	collapse: function(e) {
+		this.setState({
+			collapsed: !this.state.collapsed,
+			collapsedIcon: this.state.collapsed ? <FolderOpen /> : <FolderClosed />
+		});
+
+		e.preventDefault();
+	},
+
+
 	render: function(){
 		var onclick = e => {
 			Postal.publish({
@@ -35,20 +67,37 @@ var OutlineItem = React.createClass({
 		}
 
 		var id = 'outline-node-' + this.props.id;
+		var container = this.props.children.length > 0 && !this.state.collapsed ? <OutlineContainer children={this.props.children} /> : '';
+		var collapser = this.props.children.length > 0 ? <a className="toggle" href='#' onClick={this.collapse}>{this.state.collapsedIcon}</a> : '';
 
 		return (
 			<li key={this.props.id}>
+				{collapser}
 				<a href="#" id={id} onClick={onclick}>{this.props.title}</a>
-				<ul style={{paddingLeft: '15px'}}>{this.props.children}</ul>
+				{container}
 			</li>
 		);
 	}
 });
 
+var OutlineContainer = React.createClass({
+	render: function() {
+		return (
+			<ul className="outline-container">
+			{
+				this.props.children.map(item => {
+					return item.active ?
+					<ActiveOutlineItem key={item.id} title={item.title} children={item.children}/> :
+					<OutlineItem key={item.id} title={item.title} id={item.id} children={item.children} />
+				})
+			}
+			</ul>
+		)
+	}
+});
+
 module.exports = React.createClass({
 	render: function(){
-		var outline = buildItem(this.props.outline);
-
-		return (<ul style={{marginTop: '20px'}} className="spec-outline">{outline}</ul>);
+		return <OutlineContainer children={this.props.outline.children} />;
 	}
 });

--- a/client/public/stylesheets/storyteller.css
+++ b/client/public/stylesheets/storyteller.css
@@ -248,3 +248,7 @@ div.sentence.fact.bg-warning > pre > i.fa{
     cursor: pointer;
     margin-right: 5px;
 }
+
+.spec-outline {
+  margin-top: 20px;
+}

--- a/client/public/stylesheets/storyteller.css
+++ b/client/public/stylesheets/storyteller.css
@@ -238,3 +238,13 @@ div.sentence.fact.bg-warning > pre{
 div.sentence.fact.bg-warning > pre > i.fa{
     display: none;
 }
+
+.outline-container {
+    padding-left: 30px;
+}
+
+.outline-container-collapse {
+    color: #333;
+    cursor: pointer;
+    margin-right: 5px;
+}


### PR DESCRIPTION
I liked the idea of being able to collapse test outlines. We have very long, deep nested, outline items that we would like to be able to close and hide.

Before Collapse:
![http://i.imgur.com/q88LRyE.png](http://i.imgur.com/q88LRyE.png)

After Collapse: 
![http://i.imgur.com/PRGMIIo.png](http://i.imgur.com/PRGMIIo.png)

Notes:
It **doesn't** remove the feature of clicking on an outline item and jumping to that item in the editor.