### PR TITLE
Fix BigText Editor Display

### DIFF
--- a/client/components/editing/editors/builders.jsx
+++ b/client/components/editing/editors/builders.jsx
@@ -77,7 +77,7 @@ builders.add('select', function(arg){
 	return ( <SelectEditor arg={arg} /> );
 });
 
-builders.add('big-text', function(arg){
+builders.add('bigtext', function(arg){
 	return ( <BigText arg={arg} /> );
 })
 


### PR DESCRIPTION
Corrected key which is used in builders.jsx to lookup BigText builder. Fix for #497 