### PR TITLE
Add parameter for web socket address

### DIFF
--- a/src/ST/Client/ClientConnector.cs
+++ b/src/ST/Client/ClientConnector.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Fleck;
+using FubuCore;
 using FubuCore.Logging;
 using FubuMVC.Core.Runtime;
 using StoryTeller.Commands;
@@ -21,6 +22,7 @@ namespace ST.Client
         private readonly ILogger _logger;
         private readonly IRemoteController _controller;
         private readonly IEnumerable<ICommand> _commands;
+        private string _host;
         private int _port;
         private readonly IList<IWebSocketConnection> _sockets = new List<IWebSocketConnection>();
         private string _webSocketsAddress;
@@ -31,9 +33,8 @@ namespace ST.Client
             _logger = logger;
             _controller = controller;
             _commands = commands;
+            _host = controller.WebSocketAddress.IsNotEmpty() ? controller.WebSocketAddress : "127.0.0.1";
             _port = PortFinder.FindPort(8200);
-
-
         }
 
         public int Port => _port;
@@ -57,13 +58,10 @@ namespace ST.Client
             var increment = new Random(5).Next(1, 50);
             _port = PortFinder.FindPort(_port + increment);
 
-            // TODO -- will only work locally. What do we do otherwise?
-            _webSocketsAddress = "ws://127.0.0.1:" + _port;
+            _webSocketsAddress = "ws://" + _host + ":" + _port;
 
             try
             {
-                
-
                 _server = new WebSocketServer(_webSocketsAddress);
                 _server.Start(socket =>
                 {

--- a/src/ST/Client/RemoteController.cs
+++ b/src/ST/Client/RemoteController.cs
@@ -21,6 +21,7 @@ namespace ST.Client
         void SendMessage<T>(T message);
         RemoteController.ResponseExpression Send<T>(T message);
         QueueState QueueState();
+        string WebSocketAddress { get; set; }
     }
 
     public class RemoteController : IDisposable, IRemoteController
@@ -54,6 +55,8 @@ namespace ST.Client
         public Project Project => _project;
 
         public string Path => _path;
+
+        public string WebSocketAddress { get; set; }
 
         public string ConfigFile
         {

--- a/src/ST/CommandLine/ProjectInput.cs
+++ b/src/ST/CommandLine/ProjectInput.cs
@@ -46,6 +46,9 @@ namespace ST.CommandLine
         [Description("Force Storyteller to use this culture in all value conversions")]
         public string CultureFlag { get; set; }
 
+        [Description("Optional. Explicitly specify web socket address to use when starting server. Defaults to 127.0.0.1")]
+        public string WebSocketAddressFlag { get; set; }
+
         public RemoteController BuildRemoteController()
         {
             var path = Path.ToFullPath();
@@ -69,7 +72,10 @@ namespace ST.CommandLine
                 controller.Project.TracingStyle = "TeamCity";
             }
 
-                
+            if (WebSocketAddressFlag.IsNotEmpty())
+            {
+                controller.WebSocketAddress = WebSocketAddressFlag;
+            }
 
             controller.Project.MaxRetries = RetriesFlag;
             controller.Project.Profile = ProfileFlag;


### PR DESCRIPTION
I'm trying to migrate the client I'm working with from Fitnesse to Storyteller but the way they are accustomed to writing specifications is to have a shared server that they can all log into to write and run stories.  It would be helpful to specify the web socket address so they don't have to all spin this up locally as the specs are being written by less-technical folks.