### PR TITLE
Fix parsing of code sample directory list

### DIFF
--- a/src/ST/Docs/DocInput.cs
+++ b/src/ST/Docs/DocInput.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using FubuCore;
@@ -11,7 +12,7 @@ namespace ST.Docs
         public DocInput()
         {
             DirectoryFlag = "documentation";
-            CodeFlag = new string[]{"src"};
+            CodeFlag = new List<string>() {"src"};
         }
 
         [Description("The documentation directory. The default is 'documentation'")]
@@ -24,7 +25,7 @@ namespace ST.Docs
         public string ProjectFlag { get; set; }
 
         [Description("Override the directories where sample scanning should be enabled. Default is [src]")]
-        public string[] CodeFlag { get; set; }
+        public List<string> CodeFlag { get; set; }
 
 
 

--- a/src/ST/Docs/DocSettings.cs
+++ b/src/ST/Docs/DocSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using FubuCore;
 using ST.Docs.Html;
@@ -25,7 +26,7 @@ namespace ST.Docs
         public string Root { get; set; }
         public string WebsocketAddress { get; set; }
         public string Version { get; set; }
-        public string[] SampleDirectories { get; set; }
+        public List<string> SampleDirectories { get; set; }
         public string ProjectName { get; set; }
 
         public Type UrlResolverType()


### PR DESCRIPTION
Running ST.exe doc-run or doc-export with a -c flag currently crashes with the following exception:

```
$ ../Storyteller/src/ST/bin/Debug/ST.exe doc-run -c samples                                                                                                                                   
Error parsing input                                                                                                                                                                           
System.InvalidOperationException: Sequence contains no elements                                                                                                                               
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)                                                                                                                             
   at FubuCore.CommandLine.EnumerableFlag.Handle(Object input, Queue`1 tokens) in c:\BuildAgent\work\4dafc5966c0aefb4\src\FubuCore\CommandLine\EnumerableFlag.cs:line 24                      
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)                                                                                                  
   at FubuCore.CommandLine.UsageGraph.BuildInput(Queue`1 tokens) in c:\BuildAgent\work\4dafc5966c0aefb4\src\FubuCore\CommandLine\UsageGraph.cs:line 64                                        
   at FubuCore.CommandLine.CommandFactory.buildRun(Queue`1 queue, String commandName) in c:\BuildAgent\work\4dafc5966c0aefb4\src\FubuCore\CommandLine\CommandFactory.cs:line 81               
```

After a bit of investigation the problem turned out to be that FubuCore.CommandLine don't support arrays. Changing the property type to List&lt;string&gt; fixes the problem. :)

