### PR TITLE
Encode XML names when saving and decode on loading

### DIFF
--- a/src/StoryTeller.Testing/Model/Persistence/persisting_and_loading_specifications_with_xml.cs
+++ b/src/StoryTeller.Testing/Model/Persistence/persisting_and_loading_specifications_with_xml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
 using Shouldly;
@@ -173,9 +172,45 @@ namespace StoryTeller.Testing.Model.Persistence
             persistedStep.Collections["Letters"].Children
                 .Single().ShouldBeOfType<Comment>()
                 .Text.ShouldBe("I'm in letters");
+        }
 
+        [Test]
+        public void section_name_is_correctly_encoded()
+        {
+            original.AddSection("Total in £");
 
+            var persistedSection = persisted
+                .Children.Single().ShouldBeOfType<Section>();
 
+            persistedSection.Key.ShouldBe("Total in £");
+        }
+
+        [Test]
+        public void step_name_is_correctly_encoded()
+        {
+            original.AddSection("MySection")
+                .Children.Add(new Step("Sub Total in £"));
+
+            var persistedStep = persisted
+                .Children.Single().ShouldBeOfType<Section>()
+                .Children.Single().ShouldBeOfType<Step>();
+
+            persistedStep.Key.ShouldBe("Sub Total in £");
+        }
+
+        [Test]
+        public void step_value_are_encoded()
+        {
+            var step = new Step("MyStep").With("Total £", "1").With("Total $", "2");
+
+            original.AddSection("MySection")
+                .Children.Add(step);
+
+            var persistedStep = persisted
+                .Children.Single().ShouldBeOfType<Section>()
+                .Children.Single().ShouldBeOfType<Step>();
+
+            persistedStep.AssertValuesMatch(step);
         }
     }
 }

--- a/src/StoryTeller/Model/Persistence/XmlExtensions.cs
+++ b/src/StoryTeller/Model/Persistence/XmlExtensions.cs
@@ -23,7 +23,7 @@ namespace StoryTeller.Model.Persistence
 
         public static void WriteSection(this XmlElement parent, Section section)
         {
-            var sectionElement = parent.AddElement(section.Key);
+            var sectionElement = parent.AddElement(XmlConvert.EncodeName(section.Key));
             sectionElement.SetAttribute(XmlConstants.Id, section.id);
 
             if (section.ActiveCells.Count > 0)
@@ -49,8 +49,8 @@ namespace StoryTeller.Model.Persistence
 
         public static void WriteStep(this XmlElement parent, Step step)
         {
-            var element = parent.AddElement(step.Key);
-            step.Values.Each(pair => element.SetAttribute(pair.Key, pair.Value));
+            var element = parent.AddElement(XmlConvert.EncodeName(step.Key));
+            step.Values.Each(pair => element.SetAttribute(XmlConvert.EncodeName(pair.Key), pair.Value));
 
             step.Collections.Each(element.WriteSection);
         }

--- a/src/StoryTeller/Model/Persistence/XmlReader.cs
+++ b/src/StoryTeller/Model/Persistence/XmlReader.cs
@@ -103,7 +103,7 @@ namespace StoryTeller.Model.Persistence
 
         public static Section ReadSection(XmlElement element)
         {
-            var section = new Section(element.Name)
+            var section = new Section(XmlConvert.DecodeName(element.Name))
             {
                 id = element.GetAttribute(Id)
             };
@@ -139,13 +139,13 @@ namespace StoryTeller.Model.Persistence
 
         public static Step ReadStep(XmlElement child)
         {
-            var step = new Step(child.Name) {id = child.ReadId()};
+            var step = new Step(XmlConvert.DecodeName(child.Name)) {id = child.ReadId()};
 
             foreach (XmlAttribute att in child.Attributes)
             {
                 if (att.Name == "isStep") continue; // Old detritus
 
-                step.Values[att.Name] = att.Value;
+                step.Values[XmlConvert.DecodeName(att.Name)] = att.Value;
             }
 
             child.ForEachElement(collection =>


### PR DESCRIPTION
When the names used to define a grammar contain spaces or other special characters, then the client fails when attempting to save that fixtures using that grammar.

For example:

```c#
        [ExposeAsTable("Simple Table", "Expected Message")]
        [return: AliasAs("Expected Message")]
        public string SimpleTable(
            [Header("Name of user")]string name)
        {
            return $"Hello {name}";
        }
```