### PR TITLE
Add cli support for SystemTypeName

### DIFF
--- a/src/ST/CommandLine/ProjectInput.cs
+++ b/src/ST/CommandLine/ProjectInput.cs
@@ -49,6 +49,9 @@ namespace ST.CommandLine
         [Description("Optional. Explicitly specify web socket address to use when starting server. Defaults to 127.0.0.1")]
         public string WebSocketAddressFlag { get; set; }
 
+        [Description("Optional. Tell Storyteller which which ISystem to use")]
+        public string SystemNameFlag { get; set; }
+
         public RemoteController BuildRemoteController()
         {
             var path = Path.ToFullPath();
@@ -75,6 +78,11 @@ namespace ST.CommandLine
             if (WebSocketAddressFlag.IsNotEmpty())
             {
                 controller.WebSocketAddress = WebSocketAddressFlag;
+            }
+
+            if (SystemNameFlag.IsNotEmpty())
+            {
+                controller.Project.SystemTypeName = SystemNameFlag;
             }
 
             controller.Project.MaxRetries = RetriesFlag;

--- a/src/StoryTeller.Testing/CommandLine/run_command_integration_specs.cs
+++ b/src/StoryTeller.Testing/CommandLine/run_command_integration_specs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using FubuCore;
+using MultipleSystems;
 using NUnit.Framework;
 using Shouldly;
 using ST.Client;
@@ -122,6 +123,21 @@ namespace StoryTeller.Testing.CommandLine
 
 
             new FileSystem().WriteStringToFile(clientPath.AppendPath("batch-result-data.js"), "module.exports = " + json);
+        }
+
+        [Test]
+        public void use_specific_system_in_multi_system_project()
+        {
+            var directory = ".".ToFullPath().ParentDirectory().ParentDirectory().ParentDirectory()
+                .AppendPath("MultipleSystems");
+
+            var input = new RunInput {Path = directory, SystemNameFlag = "System2"};
+            var multiSystemController = input.BuildRemoteController();
+            var task = multiSystemController.Start(EngineMode.Batch);
+            task.Wait(3.Seconds());
+
+            task.Result.system_name.ShouldBe("MultipleSystems.System2");
+            multiSystemController.Dispose();
         }
     }
 }


### PR DESCRIPTION
This will add the ability to specify which `ISystem` to test against in the command line arguments.

```shell
st open my/project/path -s MyFirstSystem
st run my/project/path --system-name MySecondSystem
```