### PR TITLE
Allow spec path to be overridden

### DIFF
--- a/src/ST/Client/OpenInput.cs
+++ b/src/ST/Client/OpenInput.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using FubuCore;
 using StoryTeller.Model.Persistence;
 using ProjectInput = ST.CommandLine.ProjectInput;
 
@@ -7,11 +6,6 @@ namespace ST.Client
 {
     public class OpenInput : ProjectInput
     {
-        public string SpecPath
-        {
-            get { return HierarchyLoader.SelectSpecPath(Path.ToFullPath()); }
-        }
-
         public Task<Suite> ReadHierarchy()
         {
             return Task.Factory.StartNew(() => HierarchyLoader.ReadHierarchy(SpecPath));

--- a/src/ST/CommandLine/ProjectInput.cs
+++ b/src/ST/CommandLine/ProjectInput.cs
@@ -40,8 +40,23 @@ namespace ST.CommandLine
         [Description("Optional. Override the config file selection of the Storyteller test running AppDomain")]
         public string ConfigFlag { get; set; }
 
+        [Description("Optional. Override the spec directory")]
+        [FlagAlias("specs", 's')]
+        public string SpecsFlag { get; set; }
+
         [Description("Sets a minimum number of retry attempts for this execution")]
         public int RetriesFlag { get; set; }
+
+        public string SpecPath
+        {
+            get
+            {
+                if (SpecsFlag.IsNotEmpty())
+                    return SpecsFlag.ToFullPath();
+
+                return HierarchyLoader.SelectSpecPath(Path.ToFullPath());
+            }
+        }
 
         [Description("Force Storyteller to use this culture in all value conversions")]
         public string CultureFlag { get; set; }
@@ -98,11 +113,10 @@ namespace ST.CommandLine
 
         public void CreateMissingSpecFolder()
         {
-            var specFolder = HierarchyLoader.SelectSpecPath(Path.ToFullPath());
-            if (!Directory.Exists(specFolder))
+            if (!Directory.Exists(SpecPath))
             {
-                Console.WriteLine("Creating /Specs folder at " + specFolder);
-                Directory.CreateDirectory(specFolder);
+                Console.WriteLine("Creating specifications directory at " + SpecPath);
+                Directory.CreateDirectory(SpecPath);
             }
         }
 

--- a/src/ST/CommandLine/RunCommand.cs
+++ b/src/ST/CommandLine/RunCommand.cs
@@ -26,8 +26,7 @@ namespace ST.CommandLine
         {
             try
             {
-                var specFolder = HierarchyLoader.SelectSpecPath(input.Path);
-                var top = HierarchyLoader.ReadHierarchy(specFolder);
+                var top = HierarchyLoader.ReadHierarchy(input.SpecPath);
                 var specs = input.GetBatchRunRequest().Filter(top);
 
                 if (!specs.Any())

--- a/src/ST/CommandLine/RunInput.cs
+++ b/src/ST/CommandLine/RunInput.cs
@@ -46,6 +46,7 @@ namespace ST.CommandLine
             return _batchRunRequest ?? (_batchRunRequest = new BatchRunRequest
             {
                 Lifecycle = LifecycleFlag,
+                SpecPath = SpecPath,
                 Suite = WorkspaceFlag,
                 Tags = tags.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToArray()
             });

--- a/src/StoryTeller/Engine/BatchRunRequest.cs
+++ b/src/StoryTeller/Engine/BatchRunRequest.cs
@@ -11,6 +11,7 @@ namespace StoryTeller.Engine
     {
         public Lifecycle Lifecycle;
         public string Suite;
+        public string SpecPath;
         public string[] Tags;
 
         public IEnumerable<Specification> Filter(Suite top)

--- a/src/StoryTeller/Engine/Batching/BatchController.cs
+++ b/src/StoryTeller/Engine/Batching/BatchController.cs
@@ -19,8 +19,6 @@ namespace StoryTeller.Engine.Batching
 
         public void Receive(BatchRunRequest message)
         {
-            Console.WriteLine(message.SpecPath);
-
             var top = HierarchyLoader.ReadHierarchy(message.SpecPath);
             var specs = message.Filter(top).ToArray();
 

--- a/src/StoryTeller/Engine/Batching/BatchController.cs
+++ b/src/StoryTeller/Engine/Batching/BatchController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using StoryTeller.Model.Persistence;
 using StoryTeller.Remotes.Messaging;
@@ -18,7 +19,9 @@ namespace StoryTeller.Engine.Batching
 
         public void Receive(BatchRunRequest message)
         {
-            var top = HierarchyLoader.ReadHierarchy();
+            Console.WriteLine(message.SpecPath);
+
+            var top = HierarchyLoader.ReadHierarchy(message.SpecPath);
             var specs = message.Filter(top).ToArray();
 
             var task = _resultObserver.MonitorBatch(specs);

--- a/src/StoryTeller/Model/Persistence/HierarchyLoader.cs
+++ b/src/StoryTeller/Model/Persistence/HierarchyLoader.cs
@@ -8,8 +8,6 @@ namespace StoryTeller.Model.Persistence
 {
     public class HierarchyLoader
     {
-        public static readonly string SpecDirectory;
-
         public static string SelectSpecPath(string baseDirectory)
         {
             var specPath = baseDirectory.AppendPath("Specs");
@@ -24,19 +22,7 @@ namespace StoryTeller.Model.Persistence
             return specPath;
         }
 
-        static HierarchyLoader()
-        {
-            var baseDirectory = AppDomain.CurrentDomain.BaseDirectory.ToFullPath();
-            SpecDirectory = SelectSpecPath(baseDirectory);
-        }
-        
-
         public static readonly IFileSystem FileSystem = new FileSystem();
-
-        public static Suite ReadHierarchy()
-        {
-            return ReadHierarchy(SpecDirectory);
-        }
 
         public static Suite ReadHierarchy(string folder)
         {


### PR DESCRIPTION
## Overview

We're using ST to run our browser tests and our HTTP API tests. I currently have my fixtures in the same library and it's so much easier to keep it that way. However, I'm wanting to run the API tests as part of my core CI build without running the UI tests (and without keeping up with tags). I wanted to be able to simply override where ST is scanning for my specs.

## Changes

### 1. Added a new SpecsFlag on ProjectInput

If this flag is specified, the full path is used; otherwise, the `HiearchyLoader.SelectSpecPath` method is invoked against the existing `Path` property. I added a `SpecPath` property on `ProjectInput` to automatically take care of this (and removed the existing property on `OpenInput`).

### 2. Added SpecPath to BatchRunRequest

I'm not sure if this was the best way to do it but I added the spec path to the `BatchRunReqest` message. I also removed the `SpecDirectory` readonly field on `HierarchyLoader` after updating usages because now we ALWAYS pass in a path.