### PR TITLE
Wrap whitespace

### DIFF
--- a/client/public/stylesheets/storyteller.css
+++ b/client/public/stylesheets/storyteller.css
@@ -19,7 +19,7 @@ div.recycle-error {
 
 a.explorer-command {
   margin-left: 10px;
-  
+
 }
 
 a.explorer-command:link{
@@ -106,7 +106,7 @@ div.contextual-control{
 .table-column-context button{
     width: 100%;
     text-align: left
-    
+
 }
 
 
@@ -258,4 +258,23 @@ div.sentence.fact.bg-warning > pre > i.fa{
 
 .navbar {
   border-radius: 0;
+}
+
+.preview-cell {
+  white-space: pre-wrap;
+}
+
+.label-default {
+  text-align: left;
+  white-space: pre-wrap;
+}
+
+.label-danger {
+  text-align: left;
+  white-space: pre-wrap;
+}
+
+.label-success {
+  text-align: left;
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
* This makes it so big-text items do not make the window scroll
* Makes it easier to visually see newlines in strings

Before
![image](https://cloud.githubusercontent.com/assets/255007/17267999/8a7b766c-55cf-11e6-80e9-d03f00214ed5.png)

After
![image](https://cloud.githubusercontent.com/assets/255007/17268001/9d73be14-55cf-11e6-878c-000c69dfa40b.png)

Before
![image](https://cloud.githubusercontent.com/assets/255007/17268004/c2bf753c-55cf-11e6-807e-deb25dff9e4a.png)

After
![image](https://cloud.githubusercontent.com/assets/255007/17268016/5c66e508-55d0-11e6-84c0-6f0985d92add.png)
![image](https://cloud.githubusercontent.com/assets/255007/17268006/d4ee9d8c-55cf-11e6-88d1-b2115bafad8c.png)
![image](https://cloud.githubusercontent.com/assets/255007/17268008/0c35557e-55d0-11e6-896b-a2be62e701e1.png)
