### PR TITLE
allow embedded fixture to be referenced in Before() and After() method

### DIFF
--- a/src/StoryTeller.Testing/Grammars/EmbeddedSectionGrammar_specs.cs
+++ b/src/StoryTeller.Testing/Grammars/EmbeddedSectionGrammar_specs.cs
@@ -95,13 +95,13 @@ Name: Embedded
             this["BeforeColors"] = Embed<RecordingFixture>("In the recording fixture")
                 .Before(c =>
                 {
-                    RecordingFixture.Traced.Add("Before");
+                    c.Fixture.AddTrace("Before");
                 });
 
             this["AfterColors"] = Embed<RecordingFixture>("In the recording fixture")
                 .After(c =>
                 {
-                    RecordingFixture.Traced.Add("After");
+                    c.Fixture.AddTrace("After");
                 });
         }
     }
@@ -110,6 +110,11 @@ Name: Embedded
     public class RecordingFixture : Fixture
     {
         public static readonly IList<string> Traced = new List<string>();
+
+        public void AddTrace(string message)
+        {
+            Traced.Add(message);
+        }
 
         public override void SetUp()
         {

--- a/src/StoryTeller/Grammars/EmbeddedSectionGrammar.cs
+++ b/src/StoryTeller/Grammars/EmbeddedSectionGrammar.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using StoryTeller.Model;
@@ -28,15 +27,15 @@ namespace StoryTeller.Grammars
 
         public string Title { get; set; }
 
-        public EmbeddedSectionGrammar<T> Before(Action<ISpecContext> action)
+        public EmbeddedSectionGrammar<T> Before(Action<IEmbeddedSpecContext<T>> action)
         {
-            _before = action;
+            _before = x => action(new EmbeddedSpecContext<T>(x, _fixture));
             return this;
         }
 
-        public EmbeddedSectionGrammar<T> After(Action<ISpecContext> action)
+        public EmbeddedSectionGrammar<T> After(Action<IEmbeddedSpecContext<T>> action)
         {
-            _after = action;
+            _after = x => action(new EmbeddedSpecContext<T>(x, _fixture));
             return this;
         } 
 

--- a/src/StoryTeller/Grammars/EmbeddedSpecContext.cs
+++ b/src/StoryTeller/Grammars/EmbeddedSpecContext.cs
@@ -1,0 +1,57 @@
+using System;
+using StoryTeller.Engine;
+using StoryTeller.Model;
+using StoryTeller.Results;
+
+namespace StoryTeller.Grammars
+{
+    public class EmbeddedSpecContext<T>: IEmbeddedSpecContext<T>
+        where T : Fixture, new()
+    {
+        private readonly ISpecContext _specContext;
+        private readonly T _fixture;
+
+        public EmbeddedSpecContext(ISpecContext specContext, T fixture)
+        {
+            _specContext = specContext;
+            _fixture = fixture;
+        }
+
+        public T Fixture => _fixture;
+
+        public void Dispose()
+        {
+            _specContext.Dispose();
+        }
+
+        public TService Service<TService>()
+        {
+            return _specContext.Service<TService>();
+        }
+
+        public State State => _specContext.State;
+
+        public Counts Counts => _specContext.Counts;
+
+        public Specification Specification => _specContext.Specification;
+
+        public Timings Timings => _specContext.Timings;
+
+        public IReporting Reporting => _specContext.Reporting;
+
+        public bool Wait(Func<bool> condition, TimeSpan timeout, int millisecondPolling = 500)
+        {
+            return _specContext.Wait(condition, timeout, millisecondPolling);
+        }
+
+        public void LogResult<TMessage>(TMessage result) where TMessage : IResultMessage
+        {
+            _specContext.LogResult(result);
+        }
+
+        public void LogException(string id, Exception ex, object position = null)
+        {
+            _specContext.LogException(id, ex, position);
+        }
+    }
+}

--- a/src/StoryTeller/Grammars/IEmbeddedSpecContext.cs
+++ b/src/StoryTeller/Grammars/IEmbeddedSpecContext.cs
@@ -1,0 +1,8 @@
+namespace StoryTeller.Grammars
+{
+    public interface IEmbeddedSpecContext<T> : ISpecContext
+        where T : Fixture, new()
+    {
+        T Fixture { get; }
+    }
+}

--- a/src/StoryTeller/StoryTeller.csproj
+++ b/src/StoryTeller/StoryTeller.csproj
@@ -131,9 +131,11 @@
     <Compile Include="Grammars\Decisions\SetterProperty.cs" />
     <Compile Include="Grammars\Decisions\TableLineGrammar.cs" />
     <Compile Include="Grammars\EmbeddedSectionGrammar.cs" />
+    <Compile Include="Grammars\EmbeddedSpecContext.cs" />
     <Compile Include="Grammars\FactPlan.cs" />
     <Compile Include="Grammars\GrammarBuilder.cs" />
     <Compile Include="Grammars\GrammarTypes.cs" />
+    <Compile Include="Grammars\IEmbeddedSpecContext.cs" />
     <Compile Include="Grammars\Importing\CurriedLineGrammar.cs" />
     <Compile Include="Grammars\Importing\Expressions.cs" />
     <Compile Include="Grammars\Importing\ImportedExecutionStep.cs" />


### PR DESCRIPTION
This completes issue #528 