### PR TITLE
corrected the usage of font awesome 

### DIFF
--- a/documentation/documentation/docs/theme.md
+++ b/documentation/documentation/docs/theme.md
@@ -41,15 +41,16 @@ To embed the url to the root of the documentation project, use <code>&lt;[RootUr
 You can add a link to edit the current documentation topic in GitHub (or any other hosting provider) by using the `<[FilePath]>` transform like this example shown below that is taken from the Storyteller documentation itself:
 
 <pre>
-&lt;a 
+&lt;a
 	href="https://github.com/storyteller/storyteller/blob/master/documentation/&lt;[FilePath]&gt;"  
-	class="text-muted fa fa-github" 
-	&gt; Edit on GitHub&lt;/a&gt;
+	class="text-muted"&gt;
+	&lt;i class="fa fa-github"&gt;&lt;/i&gt; Edit on GitHub
+&lt;/a&gt;
 </pre>
 
 This usage results in the following html:
 
-<a href="https://github.com/storyteller/storyteller/blob/master/documentation/<[FilePath]>"  class="text-muted fa fa-github" style="margin-top: 10px"> Edit on GitHub</a>
+<a href="https://github.com/storyteller/storyteller/blob/master/documentation/<[FilePath]>"  class="text-muted" style="margin-top: 10px"><i class="fa fa-github"></i> Edit on GitHub</a>
 
 I used [font-awesome](http://fortawesome.github.io/Font-Awesome/) for the icon above, but that is neither required nor in the box for the Storyteller documentation.
 
@@ -61,7 +62,7 @@ To link to CSS files with Storyteller's pathing rules in exports, use this synta
 
 <code>&lt;[css:content/bootstrap.min.css]&gt;</code>
 
-The path in `css:[path]` should be relative to the root of the documentation directory. 
+The path in `css:[path]` should be relative to the root of the documentation directory.
 
 ## Script Files
 

--- a/documentation/layout.htm
+++ b/documentation/layout.htm
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta http-equiv="content-type" content="text/html; charset=UTF-8"> 
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8">
         <meta charset="utf-8">
         <meta name="generator" content="Bootply" />
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
@@ -10,9 +10,9 @@
 		<[css:content/storyteller.css]>
 		<[css:content/prism.css]>
 		<[css:content/theme.css]>
-		
-		
-        
+
+
+
 
         <link rel="apple-touch-icon" href="/bootstrap/img/apple-touch-icon.png">
         <link rel="apple-touch-icon" sizes="72x72" href="/bootstrap/img/apple-touch-icon-72x72.png">
@@ -23,13 +23,13 @@
         <!-- CSS code from Bootply.com editor -->
         <[css:content/affix.css]>
     </head>
-    
+
     <!-- HTML code from Bootply.com editor -->
-    
+
     <body  >
 
 <a href="https://github.com/storyteller/storyteller"><img style="z-index: 5000; position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/e7bbb0521b397edbd5fe43e7f760759336b5e05f/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677265656e5f3030373230302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png"></a>
-        
+
         <nav class="navbar navbar-default navbar-fixed-top" role="banner">
 		  <div class="container">
 		    <div class="navbar-header">
@@ -74,7 +74,7 @@
 		<div class="container">
 			<div class="row">
 		      <!--left-->
-		      
+
 		      <div class="col-md-3" id="leftCol">
 		      	<h3>Storyteller <[version]></h3>
 		      	<br />
@@ -88,11 +88,11 @@
 
 		        </ul>
 		      </div><!--/left-->
-		      
+
 		      <!--right-->
 		      <div class="col-md-9">
-			      	<h1><[title]><a href="https://github.com/storyteller/storyteller/blob/master/documentation/<[FilePath]>"  class="text-muted small pull-right fa fa-github" style="margin-top: 10px"> Edit on GitHub</a></h1>
-			      
+			      	<h1><[title]><a href="https://github.com/storyteller/storyteller/blob/master/documentation/<[FilePath]>"  class="text-muted small pull-right" style="margin-top: 10px"><i class="fa fa-github"></i> Edit on GitHub</a></h1>
+
 			      	<hr />
 
 			      	<div id="main-pane">
@@ -137,7 +137,7 @@ $('#search').keyup(function(e){
 
 
 
-}); 
+});
 
 </script>
     </body>
@@ -153,4 +153,3 @@ $('#search').keyup(function(e){
         <[script:content/affix.js]>
     </foot>
 </html>
-

--- a/documentation/splash.htm
+++ b/documentation/splash.htm
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta http-equiv="content-type" content="text/html; charset=UTF-8"> 
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8">
         <meta charset="utf-8">
         <meta name="generator" content="Bootply" />
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
@@ -14,7 +14,7 @@
     <body>
 
 <a href="https://github.com/storyteller/storyteller"><img style="z-index: 5000; position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/e7bbb0521b397edbd5fe43e7f760759336b5e05f/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677265656e5f3030373230302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png"></a>
-        
+
 
         <nav class="navbar navbar-default navbar-fixed-top" role="banner">
 		  <div class="container">
@@ -36,7 +36,7 @@
 <a href="https://gitter.im/storyteller/Storyteller?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img src="https://camo.githubusercontent.com/da2edb525cde1455a622c58c0effc3a90b9a181c/68747470733a2f2f6261646765732e6769747465722e696d2f4a6f696e253230436861742e737667" alt="Join the chat at https://gitter.im/storyteller/storyteller" data-canonical-src="https://badges.gitter.im/Join%20Chat.svg" style="max-width:100%;"></a>
 		        </li>
             <li>
-              <a href="https://github.com/storyteller/storyteller/blob/master/documentation/<[FilePath]>"  class="text-muted fa fa-github"> Edit on GitHub</a>
+              <a href="https://github.com/storyteller/storyteller/blob/master/documentation/<[FilePath]>"  class="text-muted"><i class="fa fa-github"></i> Edit on GitHub</a>
             </li>
 		      </ul>
       <div class="navbar-form navbar-left" role="search">
@@ -120,7 +120,7 @@ $('#search').keyup(function(e){
 
 
 
-}); 
+});
 
 </script>
 


### PR DESCRIPTION
<img width="217" alt="screen shot 2016-10-12 at 4 27 34 pm" src="https://cloud.githubusercontent.com/assets/6231956/19326559/0a120234-9099-11e6-8acf-db8148f82c92.png">
`fa fa-github` were being placed on the anchor tag negating the declared font-family for `<a>` (it was looking for 'Font Awesome'). 

Moved to `<i class="fa fa-github"></i>` within anchor to correct.
<img width="215" alt="screen shot 2016-10-12 at 4 30 33 pm" src="https://cloud.githubusercontent.com/assets/6231956/19326622/4541a85a-9099-11e6-9704-bf3b51404cc4.png">

