### PR TITLE
Make containers fluid

### DIFF
--- a/client/components/app.jsx
+++ b/client/components/app.jsx
@@ -56,7 +56,7 @@ export default function(initialization, register) {
         <div>
 
             <Header />
-            <div className="container">
+            <div className="container-fluid">
 
             <Router>
                 <Route name="app" path="/" >

--- a/client/components/editing/spec-editor.jsx
+++ b/client/components/editing/spec-editor.jsx
@@ -91,7 +91,7 @@ class SpecEditor extends React.Component {
     const components = spec.editors(loader);
 
     return (
-        <Grid>
+        <Grid fluid>
           <SpecHeader spec={spec} mode="editing" />
           <Row>
             <ContextualPane


### PR DESCRIPTION
Set container and Grid to be fluid so it will better contain large tables. Tables over a certain
number of columns will still overflow, but at that point it is worth considering whether or not the
table fixture is responsible for too much.

if there is a reason to keep the ST client set at 1170px then this can be disregarded.