### PR TITLE
Closes #657

### DIFF
--- a/src/StoryTeller/Files/FileChangeWatcher.cs
+++ b/src/StoryTeller/Files/FileChangeWatcher.cs
@@ -82,7 +82,7 @@ namespace StoryTeller.Files
             }
 
             if (_disposed) return;
-            _timer.Change(0, PollingIntervalInMilliseconds);
+            _timer.Change(PollingIntervalInMilliseconds, PollingIntervalInMilliseconds);
         }
 
 


### PR DESCRIPTION
High CPU load was caused by `FileChangeWatcher ` immediately restarting processing after finshing the previous run. It will now correctly consider the configured polling interval.