### PR TITLE
Spec editor scrolling improvement

### DIFF
--- a/client/components/editing/adders/step-adder-lookup.jsx
+++ b/client/components/editing/adders/step-adder-lookup.jsx
@@ -3,11 +3,12 @@ import ReactDOM from 'react-dom';
 import _ from 'lodash';
 import GrammarLookup from './../../../lib/presentation/grammar-adder-lookup';
 import $ from 'jquery';
+import scrollIntoView from 'scroll-into-view';
 
 module.exports = React.createClass({
   componentDidMount(){
     const element = ReactDOM.findDOMNode(this);
-    element.scrollIntoView();
+    scrollIntoView(element);
 
     const input = element.firstChild;
     $(input).addClass('mousetrap');
@@ -37,7 +38,7 @@ module.exports = React.createClass({
     $(element).on('typeahead:selected', function(jquery, option){
       option.select();
       $(input).val('');
-      input.scrollIntoView();
+      scrollIntoView(input);
     });
 
     input.focus();

--- a/client/components/editing/stepthrough-controls.jsx
+++ b/client/components/editing/stepthrough-controls.jsx
@@ -5,6 +5,7 @@ var {Button} = require('react-bootstrap');
 var {ButtonGroup} = require('react-bootstrap');
 var Icons = require('./../icons');
 var Mousetrap = require('mousetrap');
+import scrollIntoView from 'scroll-into-view';
 
 function StepthroughCommand({action, spec, icon, title, message}){
     if (!message){
@@ -33,18 +34,7 @@ function StepthroughCommand({action, spec, icon, title, message}){
             title={title}
             bsSize="small"
             onClick={onclick}><Icon /></Button>
-
     );
-}
-
-function scrollIntoViewIfNeeded(target) {
-    var rect = target.getBoundingClientRect();
-    if (rect.bottom > window.innerHeight) {
-        target.scrollIntoView(true);
-    }
-    if (rect.top < 0) {
-        target.scrollIntoView(true);
-    } 
 }
 
 module.exports = function({spec, showClearAll}){
@@ -54,10 +44,8 @@ module.exports = function({spec, showClearAll}){
         }
 
         var div = ReactDOM.findDOMNode(elem);
-
-        scrollIntoViewIfNeeded(div);
+        scrollIntoView(div);
     };
-
 
     var onclick = e => {
         Postal.publish({
@@ -72,9 +60,9 @@ module.exports = function({spec, showClearAll}){
     };
 
     const clearAll = (
-        <Button 
+        <Button
             bsSize="small"
-            onClick={onclick} 
+            onClick={onclick}
             title="clear all breakpoints in the current specification"><i className="fa fa-fw fa-ban"></i></Button>
     );
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-router": "^1.0.2",
     "redux": "^3.0.5",
     "rxjs": "^5.0.3",
+    "scroll-into-view": "^1.7.5",
     "typeahead": "^0.2.1"
   }
 }


### PR DESCRIPTION
Added a small js package called scroll-into-view that provides a better cross-browser implementation for scrolling to an element.  The default behavior centers the selected element rather than putting it at the top of the page, which IMO feels better.