### PR TITLE
Normalize namespaces

### DIFF
--- a/src/DatabaseSamples/DatabaseSystem.cs
+++ b/src/DatabaseSamples/DatabaseSystem.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Threading.Tasks;
 using Baseline;
 using Npgsql;
-using Storyteller.RDBMS;
+using StoryTeller.RDBMS;
 using StoryTeller;
 using StoryTeller.Engine;
 

--- a/src/DatabaseSamples/Fixtures/HiloFixture.cs
+++ b/src/DatabaseSamples/Fixtures/HiloFixture.cs
@@ -1,6 +1,5 @@
-﻿using Storyteller.RDBMS;
-using Storyteller.RDBMS.Postgresql;
-using Storyteller.RDBMS.Sets;
+﻿using StoryTeller.RDBMS.Postgresql;
+using StoryTeller.RDBMS.Sets;
 using StoryTeller;
 using StoryTeller.Grammars;
 using StoryTeller.Grammars.Tables;

--- a/src/Storyteller.AspNetCore.Samples/FakeFixture.cs
+++ b/src/Storyteller.AspNetCore.Samples/FakeFixture.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
-using StoryTeller;
 
-namespace Storyteller.AspNetCore.Samples
+namespace StoryTeller.AspNetCore.Samples
 {
     // SAMPLE: async-grammar-sample
     public class FakeFixture : AspNetCoreFixture

--- a/src/Storyteller.AspNetCore.Samples/Program.cs
+++ b/src/Storyteller.AspNetCore.Samples/Program.cs
@@ -1,7 +1,8 @@
-﻿using System.Threading;
+﻿using System;
+using Alba;
 using WebApp;
 
-namespace Storyteller.AspNetCore.Samples
+namespace StoryTeller.AspNetCore.Samples
 {
     public class Program
     {

--- a/src/Storyteller.AspNetCore/AspNetCoreFixture.cs
+++ b/src/Storyteller.AspNetCore/AspNetCoreFixture.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Alba;
-using StoryTeller;
 
-namespace Storyteller.AspNetCore
+namespace StoryTeller.AspNetCore
 {
     public abstract class AspNetCoreFixture : Fixture
     {

--- a/src/Storyteller.AspNetCore/AspNetCoreSystem.cs
+++ b/src/Storyteller.AspNetCore/AspNetCoreSystem.cs
@@ -3,12 +3,10 @@ using System.Threading.Tasks;
 using Alba;
 using Baseline;
 using Baseline.Conversion;
-using StoryTeller;
-using StoryTeller.Conversion;
 using StoryTeller.Engine;
 using StoryTeller.Equivalence;
 
-namespace Storyteller.AspNetCore
+namespace StoryTeller.AspNetCore
 {
     public class AspNetCoreSystem : ISystem
     {
@@ -24,7 +22,7 @@ namespace Storyteller.AspNetCore
 
         private readonly Task<ISystemUnderTest> _warmup;
 
-        private AspNetCoreSystem(Func<ISystemUnderTest> builder)
+        protected AspNetCoreSystem(Func<ISystemUnderTest> builder)
         {
             _warmup = Task.Factory.StartNew(() =>
             {

--- a/src/Storyteller.AspNetCore/Storyteller.AspNetCore.xproj
+++ b/src/Storyteller.AspNetCore/Storyteller.AspNetCore.xproj
@@ -4,16 +4,14 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>fdb7a0ce-d307-4a90-83b9-b92482f042f8</ProjectGuid>
-    <RootNamespace>Storyteller.AspNetCore</RootNamespace>
+    <RootNamespace>StoryTeller.AspNetCore</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/src/Storyteller.RDBMS/CheckResultExecution.cs
+++ b/src/Storyteller.RDBMS/CheckResultExecution.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Data;
-using StoryTeller;
+﻿using System.Data;
 using StoryTeller.Conversion;
 using StoryTeller.Model;
 using StoryTeller.Results;
 
-namespace Storyteller.RDBMS
+namespace StoryTeller.RDBMS
 {
     public class CheckResultExecution<T> : ICommandExecution
     {

--- a/src/Storyteller.RDBMS/CommandBuilders/IDbCommandBuilder.cs
+++ b/src/Storyteller.RDBMS/CommandBuilders/IDbCommandBuilder.cs
@@ -1,6 +1,6 @@
 ﻿using System.Data.Common;
 
-namespace Storyteller.RDBMS.CommandBuilders
+namespace StoryTeller.RDBMS.CommandBuilders
 {
     public interface IDbCommandBuilder
     {

--- a/src/Storyteller.RDBMS/CommandBuilders/SqlCommandBuilder.cs
+++ b/src/Storyteller.RDBMS/CommandBuilders/SqlCommandBuilder.cs
@@ -1,6 +1,6 @@
 ﻿using System.Data.Common;
 
-namespace Storyteller.RDBMS.CommandBuilders
+namespace StoryTeller.RDBMS.CommandBuilders
 {
     public class SqlCommandBuilder : IDbCommandBuilder
     {

--- a/src/Storyteller.RDBMS/CommandRunner.cs
+++ b/src/Storyteller.RDBMS/CommandRunner.cs
@@ -3,7 +3,7 @@ using System.Data;
 using System.Data.Common;
 using Baseline;
 
-namespace Storyteller.RDBMS
+namespace StoryTeller.RDBMS
 {
     // How to get this one in?
     public class CommandRunner : IDisposable

--- a/src/Storyteller.RDBMS/DatabaseFixture.cs
+++ b/src/Storyteller.RDBMS/DatabaseFixture.cs
@@ -3,12 +3,10 @@ using System.Collections.Generic;
 using System.Data;
 using System.Reflection;
 using Baseline;
-using Storyteller.RDBMS.Sets;
-using StoryTeller;
+using StoryTeller.RDBMS.Sets;
 using StoryTeller.Grammars;
-using StoryTeller.Model;
 
-namespace Storyteller.RDBMS
+namespace StoryTeller.RDBMS
 {
 
 

--- a/src/Storyteller.RDBMS/DbCommandGrammar.cs
+++ b/src/Storyteller.RDBMS/DbCommandGrammar.cs
@@ -1,16 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Reflection;
 using Baseline;
-using StoryTeller;
 using StoryTeller.Conversion;
 using StoryTeller.Grammars.Lines;
 using StoryTeller.Model;
 using StoryTeller.Results;
 
-namespace Storyteller.RDBMS
+namespace StoryTeller.RDBMS
 {
     public class DbCommandGrammar : LineGrammar
     {

--- a/src/Storyteller.RDBMS/ICommandExecution.cs
+++ b/src/Storyteller.RDBMS/ICommandExecution.cs
@@ -1,10 +1,9 @@
 ﻿using System.Data;
-using StoryTeller;
 using StoryTeller.Conversion;
 using StoryTeller.Model;
 using StoryTeller.Results;
 
-namespace Storyteller.RDBMS
+namespace StoryTeller.RDBMS
 {
     public interface ICommandExecution
     {

--- a/src/Storyteller.RDBMS/ISqlDialect.cs
+++ b/src/Storyteller.RDBMS/ISqlDialect.cs
@@ -1,7 +1,7 @@
 ﻿using System.Data;
 using StoryTeller.Model;
 
-namespace Storyteller.RDBMS
+namespace StoryTeller.RDBMS
 {
     public interface ISqlDialect
     {

--- a/src/Storyteller.RDBMS/NoRowsGrammar.cs
+++ b/src/Storyteller.RDBMS/NoRowsGrammar.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using StoryTeller;
 using StoryTeller.Grammars;
 
-namespace Storyteller.RDBMS
+namespace StoryTeller.RDBMS
 {
     public class NoRowsGrammar : FactGrammar
     {

--- a/src/Storyteller.RDBMS/NonQueryExecution.cs
+++ b/src/Storyteller.RDBMS/NonQueryExecution.cs
@@ -1,10 +1,9 @@
 ﻿using System.Data;
-using StoryTeller;
 using StoryTeller.Conversion;
 using StoryTeller.Model;
 using StoryTeller.Results;
 
-namespace Storyteller.RDBMS
+namespace StoryTeller.RDBMS
 {
     public class NonQueryExecution : ICommandExecution
     {

--- a/src/Storyteller.RDBMS/ParameterCell.cs
+++ b/src/Storyteller.RDBMS/ParameterCell.cs
@@ -4,7 +4,7 @@ using StoryTeller.Conversion;
 using StoryTeller.Model;
 using StoryTeller.Results;
 
-namespace Storyteller.RDBMS
+namespace StoryTeller.RDBMS
 {
     public abstract class ParameterCell
     {

--- a/src/Storyteller.RDBMS/Postgresql/NpgsqlParameterCell.cs
+++ b/src/Storyteller.RDBMS/Postgresql/NpgsqlParameterCell.cs
@@ -4,7 +4,7 @@ using Npgsql;
 using NpgsqlTypes;
 using StoryTeller.Model;
 
-namespace Storyteller.RDBMS.Postgresql
+namespace StoryTeller.RDBMS.Postgresql
 {
     public class NpgsqlParameterCell : ParameterCell
     {

--- a/src/Storyteller.RDBMS/Postgresql/PostgresDialect.cs
+++ b/src/Storyteller.RDBMS/Postgresql/PostgresDialect.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Data;
+﻿using System.Data;
 using System.Data.Common;
 using Baseline;
 using Npgsql;
 using StoryTeller.Model;
 
-namespace Storyteller.RDBMS.Postgresql
+namespace StoryTeller.RDBMS.Postgresql
 {
     public class PostgresDialect : ISqlDialect
     {

--- a/src/Storyteller.RDBMS/Postgresql/PostgresqlFixture.cs
+++ b/src/Storyteller.RDBMS/Postgresql/PostgresqlFixture.cs
@@ -1,4 +1,4 @@
-﻿namespace Storyteller.RDBMS.Postgresql
+﻿namespace StoryTeller.RDBMS.Postgresql
 {
     public abstract class PostgresqlFixture : DatabaseFixture
     {

--- a/src/Storyteller.RDBMS/Sets/BufferedReader.cs
+++ b/src/Storyteller.RDBMS/Sets/BufferedReader.cs
@@ -1,13 +1,9 @@
 ﻿using System.Collections.Generic;
-using System.Data;
 using System.Data.Common;
 using System.Linq;
-using System.Threading.Tasks;
 using Baseline;
-using StoryTeller.Conversion;
-using StoryTeller.Model;
 
-namespace Storyteller.RDBMS.Sets
+namespace StoryTeller.RDBMS.Sets
 {
     public class BufferedReader
     {

--- a/src/Storyteller.RDBMS/Sets/DbSetExecution.cs
+++ b/src/Storyteller.RDBMS/Sets/DbSetExecution.cs
@@ -1,11 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Data;
-using StoryTeller;
+﻿using System.Data;
 using StoryTeller.Conversion;
 using StoryTeller.Model;
 using StoryTeller.Results;
 
-namespace Storyteller.RDBMS.Sets
+namespace StoryTeller.RDBMS.Sets
 {
     public class DbSetExecution : ICommandExecution
     {

--- a/src/Storyteller.RDBMS/Sets/FieldById.cs
+++ b/src/Storyteller.RDBMS/Sets/FieldById.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Data.Common;
 using Baseline;
-using StoryTeller;
 using StoryTeller.Model;
 
-namespace Storyteller.RDBMS.Sets
+namespace StoryTeller.RDBMS.Sets
 {
     public class FieldById<T> : IField
     {

--- a/src/Storyteller.RDBMS/Sets/IField.cs
+++ b/src/Storyteller.RDBMS/Sets/IField.cs
@@ -2,7 +2,7 @@
 using System.Data.Common;
 using StoryTeller.Grammars.Sets;
 
-namespace Storyteller.RDBMS.Sets
+namespace StoryTeller.RDBMS.Sets
 {
     public interface IField : IColumnMatch
     {

--- a/src/Storyteller.RDBMS/Sets/RowFieldComparison.cs
+++ b/src/Storyteller.RDBMS/Sets/RowFieldComparison.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using Baseline;
-using Storyteller.RDBMS.CommandBuilders;
-using StoryTeller;
+using StoryTeller.RDBMS.CommandBuilders;
 using StoryTeller.Grammars.Sets;
 
-namespace Storyteller.RDBMS.Sets
+namespace StoryTeller.RDBMS.Sets
 {
     public class RowFieldComparison : ObjectComparison<Dictionary<string, object>>
     {

--- a/src/Storyteller.RDBMS/Sets/RowVerification.cs
+++ b/src/Storyteller.RDBMS/Sets/RowVerification.cs
@@ -1,16 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Reflection;
 using Baseline;
-using Storyteller.RDBMS.CommandBuilders;
-using StoryTeller;
+using StoryTeller.RDBMS.CommandBuilders;
 using StoryTeller.Grammars;
 using StoryTeller.Grammars.Paragraphs;
 using StoryTeller.Grammars.Sets;
 
-namespace Storyteller.RDBMS.Sets
+namespace StoryTeller.RDBMS.Sets
 {
     public class RowVerification : IGrammarSource
     {
@@ -72,9 +70,6 @@ namespace Storyteller.RDBMS.Sets
 
                 return paragraph;
             }
-
-
-
 
             return grammar;
         }

--- a/src/Storyteller.RDBMS/SpecContextExtensions.cs
+++ b/src/Storyteller.RDBMS/SpecContextExtensions.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using Baseline;
-using StoryTeller;
 
-namespace Storyteller.RDBMS
+namespace StoryTeller.RDBMS
 {
     public static class SpecContextExtensions
     {

--- a/src/Storyteller.RDBMS/SqlServer/SqlServerDialect.cs
+++ b/src/Storyteller.RDBMS/SqlServer/SqlServerDialect.cs
@@ -4,7 +4,7 @@ using System.Data.SqlClient;
 using Baseline;
 using StoryTeller.Model;
 
-namespace Storyteller.RDBMS.SqlServer
+namespace StoryTeller.RDBMS.SqlServer
 {
     public class SqlServerDialect : ISqlDialect
     {

--- a/src/Storyteller.RDBMS/SqlServer/SqlServerParameterCell.cs
+++ b/src/Storyteller.RDBMS/SqlServer/SqlServerParameterCell.cs
@@ -1,7 +1,7 @@
 ﻿using System.Data;
 using StoryTeller.Model;
 
-namespace Storyteller.RDBMS.SqlServer
+namespace StoryTeller.RDBMS.SqlServer
 {
     public class SqlServerParameterCell : ParameterCell
     {

--- a/src/Storyteller.RDBMS/Storyteller.RDBMS.xproj
+++ b/src/Storyteller.RDBMS/Storyteller.RDBMS.xproj
@@ -4,16 +4,14 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>3ce1e65c-3955-4ce9-9c9b-554af80a5223</ProjectGuid>
-    <RootNamespace>Storyteller.RDBMS</RootNamespace>
+    <RootNamespace>StoryTeller.RDBMS</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/src/Storyteller.Selenium.Samples/Program.cs
+++ b/src/Storyteller.Selenium.Samples/Program.cs
@@ -1,6 +1,4 @@
-﻿using StoryTeller;
-
-namespace Storyteller.Selenium.Samples
+﻿namespace StoryTeller.Selenium.Samples
 {
     public class Program
     {

--- a/src/Storyteller.Selenium.Samples/SampleFixture.cs
+++ b/src/Storyteller.Selenium.Samples/SampleFixture.cs
@@ -1,8 +1,7 @@
 ﻿using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
-using StoryTeller;
 
-namespace Storyteller.Selenium.Samples
+namespace StoryTeller.Selenium.Samples
 {
     public class SampleFixture : ScreenFixture
     {

--- a/src/Storyteller.Selenium.Samples/Storyteller.Selenium.Samples.xproj
+++ b/src/Storyteller.Selenium.Samples/Storyteller.Selenium.Samples.xproj
@@ -4,16 +4,14 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>3e40bd31-c8fb-4c56-bcbf-7d445400d20c</ProjectGuid>
-    <RootNamespace>Storyteller.Selenium.Samples</RootNamespace>
+    <RootNamespace>StoryTeller.Selenium.Samples</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/src/Storyteller.Selenium/ElementAttribute.cs
+++ b/src/Storyteller.Selenium/ElementAttribute.cs
@@ -1,6 +1,4 @@
-using StoryTeller;
-
-namespace Storyteller.Selenium
+namespace StoryTeller.Selenium
 {
     public class ElementAttribute : SelectionListAttribute
     {

--- a/src/Storyteller.Selenium/NamedElement.cs
+++ b/src/Storyteller.Selenium/NamedElement.cs
@@ -1,6 +1,4 @@
-using StoryTeller;
-
-namespace Storyteller.Selenium
+namespace StoryTeller.Selenium
 {
     // SAMPLE: using-selection-list-on-arguments
     [SelectionList(ScreenFixture.ElementsListName)]

--- a/src/Storyteller.Selenium/ScreenFixture.cs
+++ b/src/Storyteller.Selenium/ScreenFixture.cs
@@ -3,9 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Baseline;
 using OpenQA.Selenium;
-using StoryTeller;
 
-namespace Storyteller.Selenium
+namespace StoryTeller.Selenium
 {
     public class ScreenFixture : Fixture
     {

--- a/src/Storyteller.Selenium/Storyteller.Selenium.xproj
+++ b/src/Storyteller.Selenium/Storyteller.Selenium.xproj
@@ -4,16 +4,14 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>25f1cd74-ed41-41b3-b599-36c3f6d5781b</ProjectGuid>
-    <RootNamespace>Storyteller.Selenium</RootNamespace>
+    <RootNamespace>StoryTeller.Selenium</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>


### PR DESCRIPTION
switch from Storyteller.* to StoryTeller.* for name spaces in newer projects, i.e. StoryTeller.RMDBS
Projects that are Storyteller* remained the same, i.e. StorytellerRunner.
