### PR TITLE
Use xdg-open on linux to open files

### DIFF
--- a/src/StoryTeller/ProcessLauncher.cs
+++ b/src/StoryTeller/ProcessLauncher.cs
@@ -21,12 +21,13 @@ namespace StoryTeller
                 }
                 else
                 {
-                    Console.WriteLine("Trying to open url " + url);
+                    var openProcess = RuntimeEnvironment.OperatingSystemPlatform == Platform.Linux ? "xdg-open" : "open";
+                    Console.WriteLine("Trying to open file " + url);
 
                     Process.Start(new ProcessStartInfo
                     {
                         UseShellExecute = false,
-                        FileName = "open",
+                        FileName = openProcess,
                         Arguments = url
                     });
                 }


### PR DESCRIPTION
Current Behaviour

Run Storyteller open
Navigate to Fixtures and Grammers
Click Edit

You will see the following on the console
`Trying to open a file editor to /home/alistair/projects/quickstarts/dotnet-cli/Fixtures/Calculator.md
Trying to open url /home/alistair/projects/quickstarts/dotnet-cli/Fixtures/Calculator.md
Couldn't get a file descriptor referring to the console`

Expected:

It actually opens the file.