### PR TITLE
Update TestRail Integration: Tighten Spec-to-Case Linking

### DIFF
--- a/documentation/documentation/engine/extensions/testrail.md
+++ b/documentation/documentation/engine/extensions/testrail.md
@@ -24,6 +24,9 @@ var handling = CellHandling.Basic();
 handling.Extensions.Add(new TestRailCaseResultLoggingExtension(testRailClient));
 ```
 
-At this point you can begin establishing links between the your specs and test cases in TestRail by adding the corresponding "C" number to the name of the specs. For example, "My First Spec C1" will link to the "C1" test case in TestRail. If no test cases are found in the batch run then no Run will be created in TestRail.
+At this point you can begin establishing links between the your specs and test cases in TestRail by adding the corresponding "C#" in the name of the spec in the following format: "[C#]". For example, "My Spec [C1]" would link to Case C1 in TestRail. If no test cases are found in the batch run then no Run will be created in TestRail.
 ### Customization
 Currently there is one customization hook for this extension. When you create the `TestRailRunLoggerSettings` you can pass in your own implementation of `ITestRailRunNameGenerator` which is used to generate the name of the Test Run that will be created in TestRail. The default implementation simply uses the current date. For example, "8/8/2017 12:57:13 PM".
+
+### Getting your specs into TestRail
+Getting your specs, especially if you have a lot of them, into TestRail can be a pain. To assist with this migration there is a small utility called [StoryTeller.TestRail.Sync]("https://github.com/JarrodJ83/StoryTeller.TestRail.Sync") to sync your specs to TestRail.

--- a/src/Storyteller.TestRail/Storyteller.TestRail.csproj
+++ b/src/Storyteller.TestRail/Storyteller.TestRail.csproj
@@ -4,7 +4,7 @@
 	  <Description>TestRail integration for Storyteller</Description>
 	  <AssemblyTitle>Storyteller.TestRail</AssemblyTitle>
 	  <NeutralLanguage>en-US</NeutralLanguage>
-	  <Version>1.0.0</Version>
+	  <Version>2.0.0</Version>
 	  <Authors>Jarrod Johnson, Jeremy D. Miller</Authors>
 	  <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
 	  <DebugType>pdbonly</DebugType>

--- a/src/Storyteller.TestRail/TestCaseParser.cs
+++ b/src/Storyteller.TestRail/TestCaseParser.cs
@@ -6,14 +6,14 @@ namespace StoryTeller.TestRail
 {
     public class TestCaseParser
     {
-        private static readonly Regex _testCaseRegex = new Regex(@"([\[][Cc][0-9]+[\]])", RegexOptions.Compiled);
+        public static readonly Regex TestCaseRegex = new Regex(@"([\[][Cc][0-9]+[\]])", RegexOptions.Compiled);
 
         public static IEnumerable<int> ParseTestCaseIds(string str)
         {
             if (str == null)
                 str = "";
 
-            MatchCollection matches = _testCaseRegex.Matches(str);
+            MatchCollection matches = TestCaseRegex.Matches(str);
             
             foreach (Match match in matches)
             {

--- a/src/Storyteller.TestRail/TestCaseParser.cs
+++ b/src/Storyteller.TestRail/TestCaseParser.cs
@@ -6,7 +6,7 @@ namespace StoryTeller.TestRail
 {
     public class TestCaseParser
     {
-        private static readonly Regex _testCaseRegex = new Regex("([Cc][0-9]+)", RegexOptions.Compiled);
+        private static readonly Regex _testCaseRegex = new Regex(@"([\[][Cc][0-9]+[\]])", RegexOptions.Compiled);
 
         public static IEnumerable<int> ParseTestCaseIds(string str)
         {
@@ -19,7 +19,7 @@ namespace StoryTeller.TestRail
             {
                 if (match.Success)
                 {
-                    yield return Convert.ToInt32(match.Value.ToUpper().Replace("C", string.Empty));
+                    yield return Convert.ToInt32(match.Value.ToUpper().Replace("[C", string.Empty).Replace("]", string.Empty));
                 }
             }
         }


### PR DESCRIPTION
Realized the spec-to-case linking via the C# in the name of the specs was a bit too ambiguous. For example a spec name of "My Spec1" could be identified as linking to C1 in TestRail which would be inaccurate. To make the integration a bit more stable I decided to require the "C#" to be in the format of "[C#]". For example, "My Spec1 [C2]" would be linked to Case 2 in TestRail. 

The documentation was also updated to reflect the change as well as link to a utility that I created for one-way sinking of specs to TestRail.