### PR TITLE
Count rows in SQL Server with COUNT_BIG

### DIFF
--- a/src/Storyteller.RDBMS/SqlServer/SqlServerDialect.cs
+++ b/src/Storyteller.RDBMS/SqlServer/SqlServerDialect.cs
@@ -22,7 +22,7 @@ namespace StoryTeller.RDBMS.SqlServer
         {
             using (var cmd = conn.CreateCommand().As<DbCommand>())
             {
-                cmd.CommandText = "select count(*) from " + dbObject;
+                cmd.CommandText = "select count_big(*) from " + dbObject;
                 using (var reader = cmd.ExecuteReader())
                 {
                     return !reader.Read()


### PR DESCRIPTION
COUNT_BIG returns a bigint, which successfully casts to long.