### PR TITLE
Create a new CommandRunner if the current CommandRunner's connection is disposed

### DIFF
--- a/src/Storyteller.RDBMS/CommandRunner.cs
+++ b/src/Storyteller.RDBMS/CommandRunner.cs
@@ -12,6 +12,7 @@ namespace StoryTeller.RDBMS
 
         public ISqlDialect Dialect { get; }
         private readonly IDbConnection _connection;
+        public bool IsConnectionDisposed { get; protected set; } = false;
 
         public CommandRunner(string connectionString, ISqlDialect dialect)
         {
@@ -82,6 +83,7 @@ namespace StoryTeller.RDBMS
                 _activeTransaction.Dispose();
             }
             _connection.Dispose();
+            IsConnectionDisposed = true;
         }
 
         public void Execute(string sql)

--- a/src/Storyteller.RDBMS/SpecContextExtensions.cs
+++ b/src/Storyteller.RDBMS/SpecContextExtensions.cs
@@ -36,7 +36,13 @@ namespace StoryTeller.RDBMS
                 throw new InvalidOperationException($"No connection string is known. Use {nameof(ISpecContext)}.{nameof(SpecContextExtensions.ConnectionString)}(connection string) in your system bootstrapping");
             }
 
-            return context.State.RetrieveOrAdd(() => new CommandRunner(connectionString, dialect));
+            var commandRunner = context.State.TryRetrieve<CommandRunner>();
+            if (commandRunner == default(CommandRunner) || commandRunner.IsConnectionDisposed)
+            {
+                commandRunner = new CommandRunner(connectionString, dialect);
+                context.State.Store(commandRunner);
+            }
+            return commandRunner;
         }
 
         /// <summary>


### PR DESCRIPTION
For #725, support having multiple database fixtures in a spec by creating a new CommandRunner if the previous CommandRunner's connection has been disposed.

Without this change, a second database fixture in a spec will attempt to use the CommandRunner created for the first fixture; queries will fail because that CommandRunner's DB connection has been closed.