### PR TITLE
Use dual-mode socket to allow connections over IPV4 and V6. Resolves #713

### DIFF
--- a/src/StoryTeller/Remotes/SocketConnection.cs
+++ b/src/StoryTeller/Remotes/SocketConnection.cs
@@ -22,10 +22,9 @@ namespace StoryTeller.Remotes
         {
             _onReceived = onReceived;
                 
-            IPAddress ipAddress = Dns.GetHostAddressesAsync("localhost").GetAwaiter().GetResult()[0];
-            IPEndPoint localEndPoint = new IPEndPoint(ipAddress, port);
+            IPEndPoint localEndPoint = new IPEndPoint(IPAddress.Loopback, port);
 
-            _listener = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+            _listener = new Socket(SocketType.Stream, ProtocolType.Tcp);
 
             if (owner)
             {


### PR DESCRIPTION
The socket can now listen on 127.0.0.1 and ::1.
This prevents a SocketException when IPV6 prefix policy is set to prefer IPv4 over IPv6.

Resolves #713, at least as reproduced by @csmacnz