### PR TITLE
Explicitly check that port is available on both IPv4 and IPv6.

### DIFF
--- a/src/StoryTeller/PortFinder.cs
+++ b/src/StoryTeller/PortFinder.cs
@@ -11,16 +11,24 @@ namespace StoryTeller
         {
             for (int i = start; i < start + 50; i++)
             {
-                if (tryPort(i)) return i;
+                if (TryPort(i)) return i;
             }
 
             throw new InvalidOperationException("Could not find a port to bind to");
         }
 
-        private static bool tryPort(int port)
+        private static bool TryPort(int port)
         {
-            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.IP);
-            var endpoint = new IPEndPoint(IPAddress.Loopback, port);
+            var isV4Free = TryPortVersion(AddressFamily.InterNetwork, IPAddress.Loopback, port);
+            var isV6Free = TryPortVersion(AddressFamily.InterNetworkV6, IPAddress.IPv6Loopback, port);
+
+            return isV4Free && isV6Free;
+        }
+
+        private static bool TryPortVersion(AddressFamily family, IPAddress address, int port)
+        {
+            var socket = new Socket(family, SocketType.Stream, ProtocolType.Tcp);
+            var endpoint = new IPEndPoint(address, port);
 
             try
             {
@@ -35,7 +43,6 @@ namespace StoryTeller
             {
                 socket.SafeDispose();
             }
-
         }
     }
 }


### PR DESCRIPTION
I came across a situation where PortFinder incorrectly reported that a port was unused.

We run a service in Docker for Windows on port 5000. Docker for Windows has changed the way it opens ports on the host. It binds to 0.0.0.0 (AnyIP) for IPv4 and ::1 (localhost) for IPv6. This is not detected by PortFinder and so it reports that port 5000 is available. This results in an exception in WebApplicationRunner when it tried to start the HTTP server on port 5000.

It's not possible to detect this situation with a single socket, so I've changed it so that IPv4 and IPv6 are each tested separately.