### PR TITLE
Create IPv6-only socket to resolve #729

### DIFF
--- a/src/StoryTeller/Remotes/SocketConnection.cs
+++ b/src/StoryTeller/Remotes/SocketConnection.cs
@@ -22,9 +22,9 @@ namespace StoryTeller.Remotes
         {
             _onReceived = onReceived;
                 
-            IPEndPoint localEndPoint = new IPEndPoint(IPAddress.Loopback, port);
+            IPEndPoint localEndPoint = new IPEndPoint(IPAddress.IPv6Loopback, port);
 
-            _listener = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            _listener = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
 
             if (owner)
             {


### PR DESCRIPTION
In #727 I changed SocketConnection so that it used a dual-mode socket to allow communication over IPv4 and IPv6. This broke backwards compatibility with old versions of Storyteller referenced from the dotnet-storyteller package.

In hindsight it was only necessary to force both sides of the socket to use IPv6. This will restore backwards compatibility while still fixing #713.