### PR TITLE
Populate list options when selection list is applied to a cell

### DIFF
--- a/src/StoryTeller.Testing/Bugs/Bug_731_selection_list_options_inside_comparisons.cs
+++ b/src/StoryTeller.Testing/Bugs/Bug_731_selection_list_options_inside_comparisons.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Baseline;
+using Shouldly;
+using StoryTeller.Grammars.Sets;
+using StoryTeller.Model;
+using StoryTeller.Samples.Fixtures;
+using Xunit;
+
+namespace StoryTeller.Testing.Bugs
+{
+    public class Bug_731_selection_list_options_inside_comparisons
+    {
+        private readonly FixtureModel theModel = new SetsAndSelectionListsFixture().Compile(CellHandling.Basic());
+
+        [Fact]
+        public void works_with_option_list_name()
+        {
+            var grammar = theModel.FindGrammar("One").As<SetVerification>();
+            var cell = grammar.cells.FirstOrDefault(x => x.Key == "Name");
+
+            cell.options.Select(x => x.value).ShouldHaveTheSameElementsAs("A", "B", "C");
+            cell.editor.ShouldBe("select");
+        }
+    }
+
+    public class SetsAndSelectionListsFixture : Fixture
+    {
+        private readonly List<InvoiceDetail> _details = new List<InvoiceDetail>();
+
+        public SetsAndSelectionListsFixture()
+        {
+            AddSelectionValues("foo", "A", "B", "C");
+        }
+
+
+        public IGrammar One()
+        {
+            return VerifySetOf(() => _details)
+                .Titled("The Ordered details should be")
+                .Ordered()
+                .Comparisons(_ =>
+                {
+                    _.Compare(o => o.Amount).DefaultValue("100").Header("The Amount");
+                    _.Compare(o => o.Date);
+                    _.Compare(o => o.Name)
+                        .Header("The Name")
+                        .SelectionList("foo");
+                });
+        }
+    }
+}

--- a/src/StoryTeller/Grammars/API/SetMemberGrammar.cs
+++ b/src/StoryTeller/Grammars/API/SetMemberGrammar.cs
@@ -35,6 +35,7 @@ namespace StoryTeller.Grammars.API
             Key = members.Select(x => x.Name).Join(".");
             Members = members;
             CellModifications = new CellModifications();
+            CellModifications.Header(Key);
         }
 
         public MemberInfo Inner => Members.Last();
@@ -43,10 +44,12 @@ namespace StoryTeller.Grammars.API
 
         protected override IEnumerable<Cell> buildCells(CellHandling cellHandling, Fixture fixture)
         {
-            _cell = new Cell(cellHandling, Members.Select(x => x.Name).Join("."), Inner.GetMemberType());
-            _cell.header = Key;
-
-            CellModifications.Apply(_cell);
+            _cell = Cell.For(
+                cellHandling,
+                Members.Select(x => x.Name).Join("."),
+                Inner.GetMemberType(),
+                CellModifications,
+                fixture);
 
             return new[] { _cell };
         }

--- a/src/StoryTeller/Grammars/CheckPropertyGrammar.cs
+++ b/src/StoryTeller/Grammars/CheckPropertyGrammar.cs
@@ -22,6 +22,7 @@ namespace StoryTeller.Grammars
             Members = members;
             CellModifications = new CellModifications();
             Key = members.Select(x => x.Name).Join(".");
+            CellModifications.Header(Key);
         }
 
         public CheckPropertyGrammar(MemberInfo member) : this(new MemberInfo[] { member})
@@ -56,9 +57,12 @@ namespace StoryTeller.Grammars
         {
             var key = Members.Select(x => x.Name).Join(".");
 
-            _cell = new Cell(cellHandling, key, Members.Last().GetMemberType()) {header = key};
-
-            CellModifications.Apply(_cell);
+            _cell = Cell.For(
+                cellHandling,
+                key,
+                Members.Last().GetMemberType(),
+                CellModifications,
+                fixture);
 
             return new[] {_cell};
         }

--- a/src/StoryTeller/Grammars/ObjectBuilding/ConfigureObjectGrammar.cs
+++ b/src/StoryTeller/Grammars/ObjectBuilding/ConfigureObjectGrammar.cs
@@ -56,9 +56,7 @@ namespace StoryTeller.Grammars.ObjectBuilding
 
         protected override IEnumerable<Cell> buildCells(CellHandling cellHandling, Fixture fixture)
         {
-            _cell = new Cell(cellHandling, _key, typeof (TInput));
-
-            CellModifications.Apply(_cell);
+            _cell = Cell.For(cellHandling, _key, typeof (TInput), CellModifications, fixture);
 
             return new[] {_cell};
         }

--- a/src/StoryTeller/Grammars/ObjectBuilding/SetPropertyGrammar.cs
+++ b/src/StoryTeller/Grammars/ObjectBuilding/SetPropertyGrammar.cs
@@ -44,8 +44,7 @@ namespace StoryTeller.Grammars.ObjectBuilding
 
         protected override IEnumerable<Cell> buildCells(CellHandling cellHandling, Fixture fixture)
         {
-            _cell = new Cell(cellHandling, _accessor.Name, _accessor.PropertyType);
-            CellModifications.Apply(_cell);
+            _cell = Cell.For(cellHandling, _accessor.Name, _accessor.PropertyType, CellModifications, fixture);
 
             return new[] {_cell};
         }

--- a/src/StoryTeller/Grammars/Sets/AccessorMatch.cs
+++ b/src/StoryTeller/Grammars/Sets/AccessorMatch.cs
@@ -32,8 +32,7 @@ namespace StoryTeller.Grammars.Sets
 
         public Cell BuildCell(CellHandling handling, Fixture fixture)
         {
-            var cell = new Cell(handling, _accessor.Name, _accessor.PropertyType);
-            CellModifications.Apply(cell);
+            var cell = Cell.For(handling, _accessor.Name, _accessor.PropertyType, CellModifications, fixture);
 
             return cell;
         }

--- a/src/StoryTeller/Json/JsonValueChecks.cs
+++ b/src/StoryTeller/Json/JsonValueChecks.cs
@@ -95,8 +95,7 @@ namespace StoryTeller.Json
             public readonly CellModifications Customize = new CellModifications();
             public Cell BuildCell(CellHandling handling, Fixture fixture)
             {
-                Cell = new Cell(handling, _key, typeof(T));
-                Customize.Apply(Cell);
+                Cell = Cell.For(handling, _key, typeof(T), Customize, fixture);
 
                 return Cell;
             }

--- a/src/StoryTeller/Model/Cell.cs
+++ b/src/StoryTeller/Model/Cell.cs
@@ -161,6 +161,16 @@ namespace StoryTeller.Model
             return cell;
         }
 
+        public static Cell For(CellHandling cells, string key, Type type, CellModifications modifications, Fixture fixture)
+        {
+            var cell = new Cell(cells, key, type);
+            modifications.Apply(cell);
+
+            cell.readLists(cells, fixture);
+
+            return cell;
+        }
+        
         private void readLists(CellHandling cellHandling, Fixture fixture)
         {
             if (OptionListName.IsEmpty()) return;


### PR DESCRIPTION
Cell has some factory methods that make sure the options from a selection list are loaded. These factory methods were not used by grammars that rely on CellModifications to apply configuration to the cell.

I've added a new factory method that takes a CellModifications list and makes sure the list is loaded after the modifications are applied.

A couple of the grammars (e.g. CheckPropertiesGrammar) set a default header on the cell. This needs to be set before the CellModifications are applied. I've moved the default header into the constructor of these Grammers because that seemed the cleanest thing to do.

Fixes #731.

