### PR TITLE
Docs fix: curry defaults separator is a comma

### DIFF
--- a/src/Samples/Fixtures/CurryingFixture.cs
+++ b/src/Samples/Fixtures/CurryingFixture.cs
@@ -17,7 +17,7 @@ namespace Samples.Fixtures
         {
             return this["CreateInvoice"].Curry()
                 .Template("Invoice {Id} is open")
-                .Defaults("DueDate:TODAY+2;IsOpen:true");
+                .Defaults("DueDate:TODAY+2,IsOpen:true");
         }
     }
     // ENDSAMPLE


### PR DESCRIPTION
Make the docs match the code [here](https://github.com/storyteller/Storyteller/blob/0be855f2834f135864897e0dbdcb2919acfde6b6/src/StoryTeller/Model/Step.cs#L49).