### PR TITLE
Add optional options to specify hostname and port to which Kestrel is…

### DIFF
--- a/src/StoryTeller.Testing/ST/fixture_override_usage_and_acceptance_tests.cs
+++ b/src/StoryTeller.Testing/ST/fixture_override_usage_and_acceptance_tests.cs
@@ -175,7 +175,7 @@ namespace StoryTeller.Testing.ST
         {
         }
 
-        public IClientConnector Start(IApplication application)
+        public IClientConnector Start(IApplication application, WebApplicationConfiguration additionalConfiguration)
         {
             return Client;
         }

--- a/src/StoryTeller/Commands/StorytellerInput.cs
+++ b/src/StoryTeller/Commands/StorytellerInput.cs
@@ -24,7 +24,15 @@ namespace StoryTeller.Commands
 #endif
             
         }
-        
+
+        [Description("Optional. Bind to the specified port.")]        
+        [FlagAlias('r')]
+        public int? PortFlag { get; set; }
+
+        [Description("Optional. Bind to the specified hostname.")]
+        [FlagAlias('n')]
+        public string HostnameFlag { get; set; }
+
         [Description("Optional. Override the spec directory")]
         [FlagAlias("specs", 's')]
         public string SpecsFlag { get; set; }

--- a/src/dotnet-storyteller/Client/ApplicationController.cs
+++ b/src/dotnet-storyteller/Client/ApplicationController.cs
@@ -37,7 +37,7 @@ namespace ST.Client
         public void Start()
         {
             Engine.AssertValid();
-            Client = Website.Start(this);
+            Client = Website.Start(this, new WebApplicationConfiguration(_input.HostnameFlag, _input.PortFlag));
 
             var starting = Engine.Start();
 


### PR DESCRIPTION
… bound to. Rationale: allows exposing Storyteller to non-technical personnel - not bound to running on local machine (the WS client uses a static loopback IP, so proxying is not possible).