### PR TITLE
Add --no-build flag to run StoryTeller without building the project. …

### DIFF
--- a/src/StoryTeller/Project.cs
+++ b/src/StoryTeller/Project.cs
@@ -46,14 +46,15 @@ namespace StoryTeller
 
         public string ProjectPath { get; set; }
         public string Framework { get; set; }
-        
+        public bool NoBuild { get; set; }
+
         public string ToAgentCommandLine()
         {
-            var cmd = $"run --framework {Framework} -- agent {Port}";
+            var cmd = $"run --framework {Framework}{(NoBuild ? " --no-build" : string.Empty)} -- agent {Port}";
 
             if (Profile.IsNotEmpty()) cmd += $" --profile \"{Profile}\"";
 
-            if (Culture.IsNotEmpty()) cmd += $" --culture {Culture}";
+            if (Culture.IsNotEmpty()) cmd += $" --culture {Culture}";            
 
             foreach (var pair in Properties)
             {

--- a/src/dotnet-storyteller/Client/OpenInput.cs
+++ b/src/dotnet-storyteller/Client/OpenInput.cs
@@ -51,6 +51,10 @@ namespace ST.Client
         [FlagAlias("hotreload"), Description("Only for Storyteller development itself")]
         public bool HotReloadFlag { get; set; }
 
+        [Description("Don't build project")]
+        [FlagAlias("no-build", true)]
+        public bool NoBuildFlag { get; set; }
+
         public EngineController BuildEngine()
         {
             var project = new Project
@@ -59,7 +63,8 @@ namespace ST.Client
                 Culture = CultureFlag,
                 Profile = ProfileFlag,
                 Properties = PropFlag,
-                ProjectPath = PathFlag
+                ProjectPath = PathFlag,
+                NoBuild = NoBuildFlag
             };
 
             return new EngineController(project, new ProcessRunnerSystemLauncher(project));


### PR DESCRIPTION
…Needed for some more obscure scenarios where .NET Core CLI does not play well together with legacy project formats.