### PR TITLE
Determine WS URI on the client side. Why? My use case: ST exposed to …

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -52,7 +52,20 @@ var startRouting = app(Storyteller.initialization, store => {
 });
 
 var Communicator = require('./communicator');
-var wsAddress = Storyteller.wsAddress;
+
+function getWsAddress()
+{
+	var loc = window.location, wsUri;
+	if (loc.protocol === "https:") {
+		wsUri = "wss:";
+	} else {
+		wsUri = "ws:";
+	}
+	wsUri += "//" + loc.host;
+	return wsUri;
+}
+
+var wsAddress = getWsAddress();
 
 var rebroadcast = m => {
     Postal.publish({


### PR DESCRIPTION
…domain expert(s), proxied through NGINX that also does SSL termination -> this breaks under the current setup (of writing the address in the response on the server side).