### PR TITLE
Bug 757: Handle NULL with nullable types

### DIFF
--- a/src/StoryTeller.Testing/Bugs/handle_nullable_datetimes_correctly.cs
+++ b/src/StoryTeller.Testing/Bugs/handle_nullable_datetimes_correctly.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Baseline;
+using Baseline.Dates;
+using Samples.Fixtures;
+using Specifications.Fixtures.Docs;
+using StoryTeller.Grammars.Sets;
+using StoryTeller.Model;
+using StoryTeller.Results;
+using Xunit;
+
+namespace StoryTeller.Testing.Bugs
+{
+    public class Bug_757_handle_nullable_datetimes_correctly : SpecRunningContext
+    {
+
+
+        [Fact]
+        public void parse_null_as_valid_nullable_datetime()
+        {
+            execute(@"
+Name: Testing nullable DateTimes
+=> NullableDateTime
+* TheApprovalDateIs#1: expected=NULL
+");
+            TheStepsThatExecutedWere("1");
+            Step("1").StatusWas(ResultStatus.ok);
+
+        }
+    }
+
+    public class NullableDateTimeFixture : Fixture
+    {
+        [FormatAs("The ApprovalDate is {expected}")]
+        public DateTime? TheApprovalDateIs()
+        {
+            DateTime? approvalDate = null;
+            return approvalDate;
+        }
+    }
+ 
+}

--- a/src/StoryTeller.Testing/Bugs/handle_nullable_datetimes_correctly.cs
+++ b/src/StoryTeller.Testing/Bugs/handle_nullable_datetimes_correctly.cs
@@ -23,10 +23,15 @@ namespace StoryTeller.Testing.Bugs
 Name: Testing nullable DateTimes
 => NullableDateTime
 * TheApprovalDateIs#1: expected=NULL
+* TheApprovalDateIs#2: expected=TODAY
+* TheApprovalDateWithValueIs#3: expected=NULL
+* TheApprovalDateWithValueIs#4: expected=TODAY
 ");
-            TheStepsThatExecutedWere("1");
-            Step("1").StatusWas(ResultStatus.ok);
 
+            Step("1").Cell("expected").Succeeded();
+            Step("2").Cell("expected").FailedWithActual("NULL");
+            Step("3").Cell("expected").FailedWithActual(DateTime.Now.Date.ToString());
+            Step("4").Cell("expected").Succeeded();
         }
     }
 
@@ -36,6 +41,14 @@ Name: Testing nullable DateTimes
         public DateTime? TheApprovalDateIs()
         {
             DateTime? approvalDate = null;
+            return approvalDate;
+        }
+
+
+        [FormatAs("The TheApprovalDateWithValueIs is {expected}")]
+        public DateTime? TheApprovalDateWithValueIs()
+        {
+            DateTime? approvalDate = DateTime.Now.Date;
             return approvalDate;
         }
     }

--- a/src/StoryTeller/Equivalence/StandardEqualsPolicy.cs
+++ b/src/StoryTeller/Equivalence/StandardEqualsPolicy.cs
@@ -13,11 +13,8 @@ namespace StoryTeller.Equivalence
         {
             return (expected, actual) =>
             {
-                if (expected == null && actual == null)
-                {
-                    return true;
-                }
-                return expected.Equals(actual);
+                if (actual != null) return expected != null && expected.Equals(actual);
+                return expected == null || expected.Equals(null);
             };
         }
     }

--- a/src/StoryTeller/Equivalence/StandardEqualsPolicy.cs
+++ b/src/StoryTeller/Equivalence/StandardEqualsPolicy.cs
@@ -11,7 +11,14 @@ namespace StoryTeller.Equivalence
 
         public Func<object, object, bool> CreateComparison(Type type, EquivalenceChecker checker)
         {
-            return (expected, actual) => expected.Equals(actual);
+            return (expected, actual) =>
+            {
+                if (expected == null && actual == null)
+                {
+                    return true;
+                }
+                return expected.Equals(actual);
+            };
         }
     }
 }


### PR DESCRIPTION
Extended the StandardEqualsPolicy to compare null values on actual and expected.

The logic is:

expected (null) equals actual (null)