### PR TITLE
Make sure agent is ready only after _engine is assigned.

### DIFF
--- a/src/StoryTeller/Commands/AgentCommand.cs
+++ b/src/StoryTeller/Commands/AgentCommand.cs
@@ -19,6 +19,7 @@ namespace StoryTeller.Commands
             EventAggregator.Messaging.AddListener(this);
 
             _engine = new EngineAgent(input.Port, input.System);
+            _engine.PreStart(); // From this point messages may start being received.
 
             _completion.WaitOne();
 

--- a/src/StoryTeller/Engine/EngineAgent.cs
+++ b/src/StoryTeller/Engine/EngineAgent.cs
@@ -32,12 +32,8 @@ namespace StoryTeller.Engine
             _disposables.Add(_socket);
 
             EventAggregator.Start(_socket);
-
-            Console.WriteLine("AGENT: Sending AgentReady message");
-            EventAggregator.SendMessage(new AgentReady());
             
             _running = RunningSystem.Create(system);
-
 
             _disposables.Add(system);
         }
@@ -56,6 +52,11 @@ namespace StoryTeller.Engine
             }
         }
 
+        public void PreStart()
+        {
+            Console.WriteLine("AGENT: Sending AgentReady message");
+            EventAggregator.SendMessage(new AgentReady());
+        }
 
         public void Start(Project project)
         {


### PR DESCRIPTION
This solves https://github.com/storyteller/Storyteller/issues/747. 

The issue is caused by EngineAgent firing up AgentReady which causes other things to run concurrently and eventually a StartProject message is received in a separate thread BEFORE the constructor of EngineAgent has finished running and the instance is assigned to _engine.

Another possible solution would be to lock around the Receive mehtods and also the Execute, but that would only be useful if we had multiple concurrent calls to Receive(StartProject) which I don't know if it's possible.

I think this is the simplest solution at the moment.

Can we get this merged and released?