### PR TITLE
Updates references to https links

### DIFF
--- a/documentation/splash.htm
+++ b/documentation/splash.htm
@@ -63,7 +63,7 @@
     <div class="container">
         <div class="text-center">
         <iframe align="middle" width="420" height="315"
-src="http://www.youtube.com/embed/myDJzQvW7lY?autoplay=0">
+src="https://www.youtube.com/embed/myDJzQvW7lY?autoplay=0">
 </iframe>
         </div>
         <br />
@@ -97,8 +97,8 @@ src="http://www.youtube.com/embed/myDJzQvW7lY?autoplay=0">
 
     </div> <!-- /container -->
 
-        <script type='text/javascript' src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-        <script type='text/javascript' src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+        <script type='text/javascript' src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+        <script type='text/javascript' src="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
         <[script:content/embed.js]>
 
 


### PR DESCRIPTION
Hrefs should point to https resources whenever possible. Also accessing github pages over https breaks the embedded youtube video.